### PR TITLE
Revert 463_login_delay_obeys_to_PAM patch

### DIFF
--- a/recipes-debian/shadow/shadow/revert-463_login_delay_obeys_to_PAM.patch
+++ b/recipes-debian/shadow/shadow/revert-463_login_delay_obeys_to_PAM.patch
@@ -1,0 +1,90 @@
+diff -pNaur shadow-4.5.orig/lib/getdef.c shadow-4.5.new/lib/getdef.c
+--- shadow-4.5.orig/lib/getdef.c	2019-04-17 09:29:00.000000000 +0900
++++ shadow-4.5.new/lib/getdef.c	2019-04-17 09:30:05.924994920 +0900
+@@ -85,6 +85,7 @@ static struct itemdef def_table[] = {
+ 	{"ENV_PATH", NULL},
+ 	{"ENV_SUPATH", NULL},
+ 	{"ERASECHAR", NULL},
++	{"FAIL_DELAY", NULL},
+ 	{"FAILLOG_ENAB", NULL},
+ 	{"FAKE_SHELL", NULL},
+ 	{"FTMP_FILE", NULL},
+diff -pNaur shadow-4.5.orig/src/login.c shadow-4.5.new/src/login.c
+--- shadow-4.5.orig/src/login.c	2019-04-17 09:29:00.000000000 +0900
++++ shadow-4.5.new/src/login.c	2019-04-17 09:30:05.924994920 +0900
+@@ -525,6 +525,7 @@ int main (int argc, char **argv)
+ #if defined(HAVE_STRFTIME) && !defined(USE_PAM)
+ 	char ptime[80];
+ #endif
++	unsigned int delay;
+ 	unsigned int retries;
+ 	bool subroot = false;
+ #ifndef USE_PAM
+@@ -545,7 +546,6 @@ int main (int argc, char **argv)
+ 	pid_t child;
+ 	char *pam_user = NULL;
+ #else
+-	unsigned int delay;
+ 	struct spwd *spwd = NULL;
+ #endif
+ 	/*
+@@ -708,6 +708,7 @@ int main (int argc, char **argv)
+ 	}
+ 
+ 	environ = newenvp;	/* make new environment active */
++	delay   = getdef_unum ("FAIL_DELAY", 1);
+ 	retries = getdef_unum ("LOGIN_RETRIES", RETRIES);
+ 
+ #ifdef USE_PAM
+@@ -723,7 +724,8 @@ int main (int argc, char **argv)
+ 
+ 	/*
+ 	 * hostname & tty are either set to NULL or their correct values,
+-	 * depending on how much we know.
++	 * depending on how much we know. We also set PAM's fail delay to
++	 * ours.
+ 	 *
+ 	 * PAM_RHOST and PAM_TTY are used for authentication, only use
+ 	 * information coming from login or from the caller (e.g. no utmp)
+@@ -732,6 +734,10 @@ int main (int argc, char **argv)
+ 	PAM_FAIL_CHECK;
+ 	retcode = pam_set_item (pamh, PAM_TTY, tty);
+ 	PAM_FAIL_CHECK;
++#ifdef HAS_PAM_FAIL_DELAY
++	retcode = pam_fail_delay (pamh, 1000000 * delay);
++	PAM_FAIL_CHECK;
++#endif
+ 	/* if fflg, then the user has already been authenticated */
+ 	if (!fflg) {
+ 		unsigned int failcount = 0;
+@@ -772,6 +778,12 @@ int main (int argc, char **argv)
+ 			bool failed = false;
+ 
+ 			failcount++;
++#ifdef HAS_PAM_FAIL_DELAY
++			if (delay > 0) {
++				retcode = pam_fail_delay(pamh, 1000000*delay);
++				PAM_FAIL_CHECK;
++			}
++#endif
+ 
+ 			retcode = pam_authenticate (pamh, 0);
+ 
+@@ -1094,17 +1106,14 @@ int main (int argc, char **argv)
+ 		free (username);
+ 		username = NULL;
+ 
+-#ifndef USE_PAM
+ 		/*
+ 		 * Wait a while (a la SVR4 /usr/bin/login) before attempting
+ 		 * to login the user again. If the earlier alarm occurs
+ 		 * before the sleep() below completes, login will exit.
+ 		 */
+-		delay = getdef_unum ("FAIL_DELAY", 1);
+ 		if (delay > 0) {
+ 			(void) sleep (delay);
+ 		}
+-#endif
+ 
+ 		(void) puts (_("Login incorrect"));
+ 

--- a/recipes-debian/shadow/shadow_debian.bb
+++ b/recipes-debian/shadow/shadow_debian.bb
@@ -28,6 +28,9 @@ SRC_URI += " \
            file://0001-update-manpages.patch \
            "
 
+# Enable FAIL_DELAY in login.defs
+SRC_URI += "file://revert-463_login_delay_obeys_to_PAM.patch"
+
 # ignore: shadow-4.1.3-dots-in-usernames.patch
 # debian original/adhoc: file://0001-update-manpages.patch
 


### PR DESCRIPTION
When use package-management feature, /bin/login point to
/bin/login.shadow. Therefore /bin/login is used shadow
recipe's one.

Howereve, the 463_login_delay_obeys_to_PAM patch in debian/patches
drops to support FAIL_DELAY in login.defs[1]. However, emlinux
needs to support this feature so that emlinux's /etc/login.defs file
contains FAIL_DELAY setting. Then when user login to system,
user will get "configuration error - unknown item 'FAIL_DELAY'
(notify administrator)" error like that.

qemuarm64 login: root
configuration error - unknown item 'FAIL_DELAY' (notify administrator)
root@qemuarm64:~#

So this patch revert 463_login_delay_obeys_to_PAM to support FAIL_DELAY
in login.defs file.

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=353994