### PR TITLE
Fix package install error when building sdk

### DIFF
--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -1,0 +1,1 @@
+DUMMYPROVIDES += " busybox-syslog"


### PR DESCRIPTION
This commit fixes following error when building sdk.

WARNING: core-image-minimal-1.0-r0 do_populate_sdk: Unable to install packages. Command '/home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/recipe-sysroot-native/usr/bin/apt-get  install --force-yes --allow-unauthenticated initscripts-dbg eudev-src sysvinit-dev libz-src busybox-dbg glibc-locale-dbg base-passwd-dev base-passwd-dbg netbase-dbg base-files-dev sysvinit-dbg util-linux-dev libgcc-s-src packagegroup-core-standalone-sdk-target-dev opkg-utils-dbg packagegroup-core-standalone-sdk-target-dbg gcc-runtime-dbg packagegroup-core-boot-dbg run-postinsts-dev eudev-dev netbase-dev update-rc.d-dbg libgcc-s-dbg busybox-dev sysvinit-src glibc-src packagegroup-core-boot-dev util-linux-src run-postinsts-dbg base-passwd-src eudev-dbg busybox-src base-files-dbg kmod-dbg target-sdk-provides-dummy-dev kmod-src util-linux-dbg target-sdk-provides-dummy-dbg libz-dbg sysvinit-inittab-dev libz-dev initscripts-dev kmod-dev update-rc.d-dev sysvinit-inittab-dbg' returned 100:
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 target-sdk-provides-dummy-dev : Depends: target-sdk-provides-dummy (= 1.0-r0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.

The meta-debian-extended needed to set busybox-syslog as default syslog package.