### PR TITLE
v2: Add dependencies to target sdk provides dummy 

### DIFF
--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -4,3 +4,11 @@
 VIRTUAL-RUNTIME_base-utils-syslog ?= "busybox-syslog"
 DUMMYPROVIDES =+ " ${VIRTUAL-RUNTIME_base-utils-syslog}"
 
+VIRTUAL-RUNTIME_initscripts ?= "sysvinit"
+SYSVINIT_SCRIPTS = "${VIRTUAL-RUNTIME_base-utils-hwclock} \
+                    modutils-initscripts \
+                    init-ifupdown \
+                    ${VIRTUAL-RUNTIME_initscripts} \
+                   "
+
+DUMMYPROVIDES =+ " ${SYSVINIT_SCRIPTS}"

--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -1,0 +1,6 @@
+# Set dependencies for target-sdk-provides-dummy.
+# Poky rev: 0e392026ffefee098a890c39bc3ca1f697bacb52
+
+VIRTUAL-RUNTIME_base-utils-syslog ?= "busybox-syslog"
+DUMMYPROVIDES =+ " ${VIRTUAL-RUNTIME_base-utils-syslog}"
+


### PR DESCRIPTION
Changed from v1(#9 )
- base branch is rebased to latest code.

# descriptions

This pr contains 2 commits, that fixes following error in sdk build process.

```
WARNING: core-image-minimal-1.0-r0 do_populate_sdk: Unable to install packages. Command '/home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/recipe-sysroot-native/usr/bin/apt-get  install --force-yes --allow-unauthenticated eudev-dbg target-sdk-provides-dummy-dev eudev-src kmod-src packagegroup-core-boot-dbg initscripts-dev update-rc.d-dev init-ifupdown-dbg libgcc-s-dbg sysvinit-dbg packagegroup-core-standalone-sdk-target-dev libz-dev eudev-dev netbase-dbg base-files-dev util-linux-dbg run-postinsts-dev netbase-dev sysvinit-inittab-dbg busybox-dev base-passwd-src update-rc.d-dbg sysvinit-dev busybox-src kmod-dev kmod-dbg opkg-utils-dbg util-linux-dev busybox-dbg util-linux-src glibc-src base-passwd-dbg sysvinit-inittab-dev target-sdk-provides-dummy-dbg modutils-initscripts-dev glibc-locale-dbg base-files-dbg packagegroup-core-standalone-sdk-target-dbg run-postinsts-dbg modutils-initscripts-dbg libz-src packagegroup-core-boot-dev initscripts-dbg libz-dbg libgcc-s-src gcc-runtime-dbg base-passwd-dev sysvinit-src init-ifupdown-dev' returned 100:
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 target-sdk-provides-dummy-dev : Depends: target-sdk-provides-dummy (= 1.0-r0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.

NOTE: Tasks Summary: Attempted 2991 tasks of which 1679 didn't need to be rerun and all succeeded.
```

To remove the error, it needed to set syslog and sysvinit script dependencies.

Commit  f6d9708  set syslog dependency.  Commit 67214a0 overrides SYSVINIT_SCRIPTS variable and set it to DUMMYPROVIDES.

