### PR TITLE
seabios: Fix  qa error in sdk build

### DIFF
--- a/recipes-debian/seabios/seabios_debian.bb
+++ b/recipes-debian/seabios/seabios_debian.bb
@@ -117,5 +117,5 @@ do_install() {
     install -m 0644 ${B}/out/src/fw/q35-acpi-dsdt.aml ${D}/${prefix}/share/seabios/
 }
 
-
+FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}"
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
To build nativesdk, it should install files to /opt.