### PR TITLE
WIP: Add missing libxcb patches

### DIFF
--- a/recipes-debian/xorg-lib/libxcb/disable-check.patch
+++ b/recipes-debian/xorg-lib/libxcb/disable-check.patch
@@ -1,0 +1,25 @@
+The "check" package is checked for without an explicit enable/disable option,
+which can lead to non-deterministic build issues with both check and libxslt.
+
+As the unit test suite is minimal at present, simply disable the test suite.  In
+the future if the test suite is expanded this can be made conditional on the
+ptest DISTRO_FEATURE.
+
+Upstream-Status: Inappropriate
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+
+diff --git a/configure.ac b/configure.ac
+index 6d7c9a5..22cceb9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -21,7 +21,8 @@ AC_USE_SYSTEM_EXTENSIONS
+ 
+ AM_PATH_PYTHON([2.6])
+ 
+-PKG_CHECK_MODULES(CHECK, [check >= 0.9.4], [HAVE_CHECK=yes], [HAVE_CHECK=no])
++dnl PKG_CHECK_MODULES(CHECK, [check >= 0.9.4], [HAVE_CHECK=yes], [HAVE_CHECK=no])
++HAVE_CHECK=no
+ AM_CONDITIONAL(HAVE_CHECK, test x$HAVE_CHECK = xyes)
+ 
+ AC_CONFIG_HEADERS([src/config.h])

--- a/recipes-debian/xorg-lib/libxcb/gcc-mips-pr68302-mips-workaround.patch
+++ b/recipes-debian/xorg-lib/libxcb/gcc-mips-pr68302-mips-workaround.patch
@@ -1,0 +1,22 @@
+Reduce debug info for xcb.c since on mips we run into a gcc5 bug
+
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68302
+
+This patch is a workaround to get past the gcc bug until its resolved.
+it should have minimal impact on libxcb while make it work.
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: libxcb-1.11.1/src/Makefile.am
+===================================================================
+--- libxcb-1.11.1.orig/src/Makefile.am
++++ libxcb-1.11.1/src/Makefile.am
+@@ -188,6 +188,7 @@ EXTSOURCES += xkb.c
+ if BUILD_XKB
+ lib_LTLIBRARIES += libxcb-xkb.la
+ libxcb_xkb_la_LDFLAGS = -version-info 1:0:0 -no-undefined
++CFLAGS += -g1
+ libxcb_xkb_la_LIBADD = $(XCB_LIBS)
+ nodist_libxcb_xkb_la_SOURCES = xkb.c xkb.h
+ endif

--- a/recipes-debian/xorg-lib/libxcb/xcbincludedir.patch
+++ b/recipes-debian/xorg-lib/libxcb/xcbincludedir.patch
@@ -1,0 +1,28 @@
+As pkg-config --variable doesn't respect the sysroot, add the pkg-config sysroot
+to the beginning of variables that are used later on the host.
+
+Upstream-Status: Pending
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/configure.ac b/configure.ac
+index 94da4f7..d29cd6a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -64,7 +64,7 @@ AC_SUBST(NEEDED)
+ 
+ # Find the xcb-proto protocol descriptions
+ AC_MSG_CHECKING(XCBPROTO_XCBINCLUDEDIR)
+-XCBPROTO_XCBINCLUDEDIR=`$PKG_CONFIG --variable=xcbincludedir xcb-proto`
++XCBPROTO_XCBINCLUDEDIR=$PKG_CONFIG_SYSROOT_DIR/`$PKG_CONFIG --variable=xcbincludedir xcb-proto`
+ AC_MSG_RESULT($XCBPROTO_XCBINCLUDEDIR)
+ AC_SUBST(XCBPROTO_XCBINCLUDEDIR)
+ 
+@@ -74,7 +74,7 @@ AC_SUBST(XCBPROTO_VERSION)
+ 
+ # Find the xcbgen Python package
+ AC_MSG_CHECKING(XCBPROTO_XCBPYTHONDIR)
+-XCBPROTO_XCBPYTHONDIR=`$PKG_CONFIG --variable=pythondir xcb-proto`
++XCBPROTO_XCBPYTHONDIR=$PKG_CONFIG_SYSROOT_DIR/`$PKG_CONFIG --variable=pythondir xcb-proto`
+ AC_MSG_RESULT($XCBPROTO_XCBPYTHONDIR)
+ AC_SUBST(XCBPROTO_XCBPYTHONDIR)
+ 


### PR DESCRIPTION
this recipe is referencing patches that doesn't exist
https://github.com/miraclelinux/meta-debian-extended/blob/7adca61218e9e46095a988560c8379a82eddb11c/recipes-debian/xorg-lib/libxcb_debian.bb#L17