### PR TITLE
V2 util linux fix ptest error

### DIFF
--- a/recipes-debian/util-linux/util-linux/0001-tests-check-kernel-btrfs-support.patch
+++ b/recipes-debian/util-linux/util-linux/0001-tests-check-kernel-btrfs-support.patch
@@ -1,0 +1,32 @@
+From 26cd9bcbc3e6b8a19930bf4560ba2b5cad0ddfa4 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Tue, 2 Jul 2019 14:43:39 +0900
+Subject: [PATCH] tests: check kernel btrfs support
+
+Check kernel supports btrfs or not before run tests.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/ts/mount/fstab-btrfs | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tests/ts/mount/fstab-btrfs b/tests/ts/mount/fstab-btrfs
+index 54c6bb8..aa419ca 100755
+--- a/tests/ts/mount/fstab-btrfs
++++ b/tests/ts/mount/fstab-btrfs
+@@ -21,6 +21,12 @@ TS_DESC="btrfs (fstab)"
+ . $TS_TOPDIR/functions.sh
+ ts_init "$*"
+ 
++# btrfs kernel support check
++grep btrfs /proc/filesystems &>/dev/null
++if [ $? -ne 0 ]; then
++    ts_skip "kernel does not support btrfs"
++fi
++
+ ts_check_test_command "$TS_CMD_MOUNT"
+ ts_check_test_command "$TS_CMD_UMOUNT"
+ 
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/util-linux/0001-tests-check-kernel-raid-support.patch
+++ b/recipes-debian/util-linux/util-linux/0001-tests-check-kernel-raid-support.patch
@@ -1,0 +1,48 @@
+From 873f903e7fbd74b4c955eab8d10199a5077dab61 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Wed, 3 Jul 2019 17:12:26 +0900
+Subject: [PATCH] tests: check kernel raid support
+
+To check kernel raid support for ignore test error when kernel doesn't
+support raid.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/ts/blkid/md-raid0-whole | 4 ++++
+ tests/ts/blkid/md-raid1-whole | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/tests/ts/blkid/md-raid0-whole b/tests/ts/blkid/md-raid0-whole
+index 45c6ee5..f873be4 100755
+--- a/tests/ts/blkid/md-raid0-whole
++++ b/tests/ts/blkid/md-raid0-whole
+@@ -48,6 +48,10 @@ ts_log "Create RAID device"
+ mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=0 \
+ 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>&1
+ 
++if [ ! -d "/sys/module/md_mod/parameters/new_array" ]; then
++  ts_skip "kernel doesn't support raid"
++fi
++
+ ts_log "Create partitions on RAID device"
+ $TS_CMD_FDISK ${MD_DEVICE} >> $TS_OUTPUT 2>&1 <<EOF
+ n
+diff --git a/tests/ts/blkid/md-raid1-whole b/tests/ts/blkid/md-raid1-whole
+index ddf4a69..a4f3364 100755
+--- a/tests/ts/blkid/md-raid1-whole
++++ b/tests/ts/blkid/md-raid1-whole
+@@ -49,6 +49,11 @@ udevadm settle
+ ts_log "Create RAID device"
+ mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=1 \
+ 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>&1
++
++if [ ! -d "/sys/module/md_mod/parameters/new_array" ]; then
++  ts_skip "kernel doesn't support raid"
++fi
++
+ udevadm settle
+ 
+ ts_log "Create partitions on RAID device"
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/util-linux/0001-tests-fix-test-failed-on-busybox-environment.patch
+++ b/recipes-debian/util-linux/util-linux/0001-tests-fix-test-failed-on-busybox-environment.patch
@@ -1,0 +1,46 @@
+From 6be5850858be91d750d4a7830607212f1c10cb76 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Wed, 3 Jul 2019 10:12:17 +0900
+Subject: [PATCH] tests: fix test failed on busybox environment
+
+Remove \r from expected file to ignore newline code difference error.
+Add -B option to diff to ignore empty lines.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/expected/script/options-size | 4 ++--
+ tests/functions.sh                 | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/expected/script/options-size b/tests/expected/script/options-size
+index c984dfa..dcea580 100644
+--- a/tests/expected/script/options-size
++++ b/tests/expected/script/options-size
+@@ -1,9 +1,9 @@
+ Script started on 2015-05-24 17:43:18+00:00 [<not executed on terminal>]
+-1:1234567890
++1:1234567890
+ 
+ Script done on 2015-05-24 17:43:18+00:00 [<max output size exceeded>]
+ Script started on 2015-05-24 17:43:18+00:00 [<not executed on terminal>]
+-2:1234567890
++2:1234567890
+ 
+ Script done on 2015-05-24 17:43:18+00:00 [<max output size exceeded>]
+ 0
+diff --git a/tests/functions.sh b/tests/functions.sh
+index 2fb0ddb..e3b5f3b 100644
+--- a/tests/functions.sh
++++ b/tests/functions.sh
+@@ -421,7 +421,7 @@ function ts_gen_diff {
+ 	sed --in-place 's/^lt\-\(.*\: \)/\1/g' $TS_OUTPUT
+ 
+ 	[ -d "$TS_DIFFDIR" ] || mkdir -p "$TS_DIFFDIR"
+-	diff -u $TS_EXPECTED $TS_OUTPUT > $TS_DIFF
++	diff -uB $TS_EXPECTED $TS_OUTPUT > $TS_DIFF
+ 
+ 	if [ $? -ne 0 ] || [ -s $TS_DIFF ]; then
+ 		res=1
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -29,4 +29,5 @@ SRC_URI += "file://configure-sbindir.patch \
             file://avoid_parallel_tests.patch \
             file://check-for-_HAVE_STRUCT_TERMIOS_C_OSPEED.patch \
             file://0001-tests-check-kernel-btrfs-support.patch \
+            file://0001-tests-fix-test-failed-on-busybox-environment.patch \
 "

--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -30,4 +30,5 @@ SRC_URI += "file://configure-sbindir.patch \
             file://check-for-_HAVE_STRUCT_TERMIOS_C_OSPEED.patch \
             file://0001-tests-check-kernel-btrfs-support.patch \
             file://0001-tests-fix-test-failed-on-busybox-environment.patch \
+            file://0001-tests-check-kernel-raid-support.patch \
 "

--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -28,4 +28,5 @@ SRC_URI += "file://configure-sbindir.patch \
             file://display_testname_for_subtest.patch \
             file://avoid_parallel_tests.patch \
             file://check-for-_HAVE_STRUCT_TERMIOS_C_OSPEED.patch \
+            file://0001-tests-check-kernel-btrfs-support.patch \
 "

--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -32,3 +32,6 @@ SRC_URI += "file://configure-sbindir.patch \
             file://0001-tests-fix-test-failed-on-busybox-environment.patch \
             file://0001-tests-check-kernel-raid-support.patch \
 "
+
+RDEPENDS_${PN}-ptest += "tar"
+


### PR DESCRIPTION
Some tests failed on qemuarm64. However run these tests on Debian Buster x86-64 environment tests aren't failed. So these test failures seem environment specific issue.

v2:
- Do not skip ul tests in util-linux's recipe
- Use GNU tar for ptest

v1:
- check btrfs kernel support
- add diff option to support test environment difference
