### PR TITLE
sqlite3: fix bugs

### DIFF
--- a/recipes-debian/sqlite3/sqlite3.inc
+++ b/recipes-debian/sqlite3/sqlite3.inc
@@ -68,6 +68,11 @@ do_configure_append() {
   mv ${B}/${TARGET_PREFIX}libtool ${B}/libtool
 }
 
+do_install_append() {
+  install -d ${D}/${mandir}/man1
+  install -m 0644 ${S}/sqlite3.1 ${D}/${mandir}/man1
+}
+
 PACKAGES = "lib${BPN} lib${BPN}-dev lib${BPN}-doc ${PN}-dbg lib${BPN}-staticdev ${PN}"
 
 FILES_${PN} = "${bindir}/*"

--- a/recipes-debian/sqlite3/sqlite3.inc
+++ b/recipes-debian/sqlite3/sqlite3.inc
@@ -9,7 +9,7 @@ LICENSE = "PD"
 LIC_FILES_CHKSUM = "file://autoconf/tea/license.terms;md5=5e0405ae78edb434653628790bb02b17"
 
 PE = "3"
-DEPENDS = "tcl-native"
+DEPENDS = "tcl tcl-native"
 
 inherit debian-package
 require recipes-debian/sources/sqlite3.inc
@@ -20,7 +20,6 @@ inherit autotools pkgconfig
 
 # enable those which are enabled by default in configure
 PACKAGECONFIG ?= "fts4 fts5 json1 rtree"
-#PACKAGECONFIG_class-native ?= "fts4 fts5 json1 rtree dyn_ext"
 
 PACKAGECONFIG[editline] = "--enable-editline,--disable-editline,libedit"
 PACKAGECONFIG[readline] = "--enable-readline,--disable-readline,readline ncurses"
@@ -53,9 +52,10 @@ EXTRA_OECONF = " \
     --enable-shared \
     --enable-threadsafe \
     --enable-load-extension \
-    TCLLIBDIR=${prefix}/lib/tcltk/sqlite3 \
+    --with-tcl=${STAGING_DIR_TARGET}/usr/lib \
+    --disable-tcl \
 "
-
+    
 CFLAGS_append = " -fPIC -O2 -fno-strict-aliasing"
 
 # pread() is in POSIX.1-2001 so any reasonable system must surely support it
@@ -78,4 +78,3 @@ FILES_lib${BPN}-doc = "${docdir} ${mandir} ${infodir}"
 FILES_lib${BPN}-staticdev = "${libdir}/lib*.a"
 
 AUTO_LIBNAME_PKGS = "${MLPREFIX}lib${BPN}"
-


### PR DESCRIPTION
This pr contains two commit to fixes two bugs.

### sqlite3: Fixes: don't use host's tclConfig.sh command

This patch fix to use build environment tclConfig.sh instead of host's one. The configure script use tclConfig.sh. If build host installed tcl-dev package, configure script uses /usr/bin/tclConfig.sh which is provided by tcl-dev package.
So, it should use build environment's tclConfig.sh.

### sqlite3: Fixes: add man file in package

Current sqlite3_debian.bb doesn't provide man file but poky does. This patch add man file in sqilte3 package.

