### PR TITLE
diffutils: Fixes: Add perl to rdepends for ptest

### DIFF
--- a/recipes-debian/diffutils/diffutils_debian.bb
+++ b/recipes-debian/diffutils/diffutils_debian.bb
@@ -15,7 +15,7 @@ acpaths = "-I ./m4"
 
 inherit ptest
 
-RDEPENDS_${PN}-ptest += "make"
+RDEPENDS_${PN}-ptest += "make perl"
 
 do_install_ptest() {
 	t=${D}${PTEST_PATH}


### PR DESCRIPTION
The diffutils test failed because perl is not in test system by default.

```
XPASS: large-subopt
===================

./large-subopt: line 21: perl: command not found
XPASS large-subopt (exit status: 0)

SKIP: strip-trailing-cr
=======================
```
Add perl in rdepends for ptest to test work fine.

Then, got XFAIL in same test.
```
XFAIL: large-subopt
```
Changelog describes XFAIL mean.
```
2017-10-22  Jim Meyering  <meyering@fb.com>

        tests: add expected-failing test for minor subopimality
        In some unusual cases, diff -u prints suboptimal output.
        * tests/large-subopt: New test script.
        * tests/Makefile.am (TESTS): Add it.
        (XFAIL_TESTS): Add it here, too, to record that this test is
        currently expected to fail.
        * tests/large-subopt.in1, tests/large-subopt.in2: Inputs derived from
        those in http://bugs.gnu.org/28796
```
In Makefile, large-subopt is marked as XFAIL_TEST that changelog describes it means.
```
XFAIL_TESTS = large-subopt
EXTRA_DIST = \
  $(TESTS) init.cfg init.sh t-local.sh envvar-check \
  large-subopt.in1 \
  large-subopt.in2
```
So, it's ok to ignore large-subopt test failed as XFAIL.