### PR TITLE
libgpg-error: Fix build errors related pkg-conf

### DIFF
--- a/recipes-debian/libgpg-error/libgpg-error_debian.bb
+++ b/recipes-debian/libgpg-error/libgpg-error_debian.bb
@@ -17,6 +17,9 @@ SECTION = "libs"
 inherit debian-package
 require recipes-debian/sources/libgpg-error.inc
 
+FILESPATH_append = ":${COREBASE}/meta/recipes-support/libgpg-error/libgpg-error:"
+SRC_URI += "file://pkgconfig.patch"
+
 BINCONFIG = "${bindir}/gpg-error-config"
 
 inherit autotools binconfig-disabled pkgconfig gettext multilib_header multilib_script


### PR DESCRIPTION
Without poky's patch build errors related pkg-conf occur. This commit fixes them.

  ERROR: /usr/bin/gpg-error-config should not be used, use an alternative such as pkg-config
  ../libgcrypt-1.8.4/configure: line 14691: test: --should-not-have-used-/usr/bin/gpg-error-config: integer expression expected
  ../libgcrypt-1.8.4/configure: line 14694: test: --should-not-have-used-/usr/bin/gpg-error-config: integer expression expected
  ../libgcrypt-1.8.4/configure: line 14701: test: --should-not-have-used-/usr/bin/gpg-error-config: integer expression expected
  checking for GPG Error - version >= 1.25... no