### PR TITLE
libepoxy: Fix gtk+3 can't find epoxy/glx.h

### DIFF
--- a/recipes-debian/libepoxy/libepoxy_debian.bb
+++ b/recipes-debian/libepoxy/libepoxy_debian.bb
@@ -26,8 +26,9 @@ PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)} egl"
 
 EXTRA_OEMESON += "-Dtests=false"
 
-PACKAGECONFIG_class-native = "egl"
-PACKAGECONFIG_class-nativesdk = "egl"
+PACKAGECONFIG_class-native ??= "${@bb.utils.filter('DISTRO_FEATURES_NATIVE', 'x11', d)} egl"
+
+PACKAGECONFIG_class-native ??= "${@bb.utils.filter('DISTRO_FEATURES_NATIVESDK', 'x11', d)} egl"
 
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
Previously PACKAGECONFIG_class-native and PACKAGECONFIG_class-nativesdk
are set "egl". This causes build failure when you set PACKAGECONFIG_app
end_pn-qemu-system-native to "gtk+3" because it refers "epoxy/glx.h"