### PR TITLE
qemu: Add PACKAGECONFIG for glusterfs

### DIFF
--- a/recipes-debian/qemu/qemu.inc
+++ b/recipes-debian/qemu/qemu.inc
@@ -159,6 +159,7 @@ PACKAGECONFIG[bluez] = "--enable-bluez,--disable-bluez,${BLUEZ}"
 PACKAGECONFIG[libiscsi] = "--enable-libiscsi,--disable-libiscsi"
 PACKAGECONFIG[kvm] = "--enable-kvm,--disable-kvm"
 PACKAGECONFIG[virglrenderer] = "--enable-virglrenderer,--disable-virglrenderer,virglrenderer"
+PACKAGECONFIG[glusterfs] = "--enable-glusterfs,--disable-glusterfs,"
 # spice will be in meta-networking layer
 PACKAGECONFIG[spice] = "--enable-spice,--disable-spice,spice"
 # usbredir will be in meta-networking layer


### PR DESCRIPTION
Currently glusterfs is enable by default, but it is not used in poky and
depends on libglusterfs in host. It was changed to set PACKAGECONFIG.