### PR TITLE
libxml-parser-perl: fix ptest dependencies

### DIFF
--- a/recipes-debian/perl/libxml-parser-perl_debian.bb
+++ b/recipes-debian/perl/libxml-parser-perl_debian.bb
@@ -52,6 +52,6 @@ do_install_ptest() {
 	chown -R root:root ${D}${PTEST_PATH}/samples
 }
 
-RDEPENDS_${PN}-ptest += "perl-module-test-more"
+RDEPENDS_${PN}-ptest += "perl-module-filehandle perl-module-if perl-module-test perl-module-test-more"
 
 BBCLASSEXTEND="native nativesdk"


### PR DESCRIPTION
Backported from yocto master 729cd9c6e9e34d6d0e1334ad0bb59a6c84be4540.