### PR TITLE
glibc: Add locales package.

### DIFF
--- a/recipes-debian/glibc/glibc-locale_debian.bbappend
+++ b/recipes-debian/glibc/glibc-locale_debian.bbappend
@@ -1,0 +1,1 @@
+PACKAGES_DYNAMIC += " ^glibc-locale-.*"

--- a/recipes-debian/glibc/glibc_debian.bbappend
+++ b/recipes-debian/glibc/glibc_debian.bbappend
@@ -1,0 +1,25 @@
+PACKAGES += "locales"
+PROVIDES += "locales"
+
+FILES_locales = "${sbindir}/locale-gen ${sbindir}/update-locale ${sbindir}/validlocale \
+    ${libdir}/locale"
+FILES_${PN}-utils_remove = "${sbindir}/*"
+FILES_${PN}-utils += "${sbindir}/iconvconfig"
+
+RDEPENDS_locales = "glibc perl \
+    perl-module-getopt-long \
+    perl-module-posix \
+    perl-module-carp \
+"
+DESCRIPTION_locales = "locales utils -- locale-gen, update-locale, validlocale"
+
+do_install_append () {
+    if ${@bb.utils.contains('IMAGE_INSTALL', "locales", 'true', 'false', d)}; then
+        install -d ${D}/${sbindir}
+        install -m 0755 ${S}/debian/local/usr_sbin/* ${D}/${sbindir}
+    fi
+}
+
+do_poststash_install_cleanup_append() {
+    install -d ${D}/${libdir}/locale
+}


### PR DESCRIPTION
Confirmed that the following commands work.

validlocale ja_JP.UTF-8
-> locale 'ja_JP.UTF-8' not available

mkdir /usr/lib/locale/
echo ja_JP.UFT-8 UTF-8 > /etc/locale.gen
locale-gen
locale -a
-> ja_JP.utf8

validlocale ja_JP.UTF-8
-> locale 'ja_JP.UTF-8' valid and available

update-locale LANG=ja_JP.UTF-8
cat /etc/default/locale
-> LANG=ja_JP.UTF-8