### PR TITLE
nettle: fix dlopen test

### DIFF
--- a/recipes-debian/nettle/nettle/dlopen-test.patch
+++ b/recipes-debian/nettle/nettle/dlopen-test.patch
@@ -1,0 +1,20 @@
+Replace relative path of libnettle.so with absolute path so the test
+program can find it.
+Relative paths are not suitable, as the folder strucure for ptest
+is different from the one expected by the nettle testsuite.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>
+
+--- a/testsuite/dlopen-test.c	2016-10-01 00:28:38.000000000 -0700
++++ b/testsuite/dlopen-test.c	2017-10-13 11:08:57.227572860 -0700
+@@ -9,7 +9,7 @@
+ main (int argc UNUSED, char **argv UNUSED)
+ {
+ #if HAVE_LIBDL
+-  void *handle = dlopen ("../libnettle.so", RTLD_NOW);
++  void *handle = dlopen ("/usr/lib/libnettle.so.6", RTLD_NOW);
+   int (*get_version)(void);
+   if (!handle)
+     {


### PR DESCRIPTION
libnettle.so does not exist, but libnettle.so.6.