### PR TITLE
nettle: ptest: fix symbol-test fail

### DIFF
--- a/recipes-debian/nettle/nettle_debian.bb
+++ b/recipes-debian/nettle/nettle_debian.bb
@@ -46,6 +46,7 @@ do_install_append() {
     oe_multilib_header nettle/nettle-stdint.h nettle/version.h
 }
 
+RDEPENDS_${PN}-ptest += "binutils"
 do_install_ptest() {
         install -d ${D}${PTEST_PATH}/testsuite/
         install ${S}/testsuite/gold-bug.txt ${D}${PTEST_PATH}/testsuite/
@@ -53,6 +54,9 @@ do_install_ptest() {
         # tools can be found in PATH, not in ../tools/
         sed -i -e 's|../tools/||' ${D}${PTEST_PATH}/testsuite/*-test
         install ${B}/testsuite/*-test ${D}${PTEST_PATH}/testsuite/
+	install ${B}/version.h ${D}${PTEST_PATH}/
+	install ${B}/libhogweed.a ${D}${PTEST_PATH}/
+	install ${B}/libnettle.a ${D}${PTEST_PATH}/
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Added binutils package in RDEPENDS to nettle-ptest package because
symbol-test requires nm command.

Added version.h and static libraies in ${PTEST_PATH} which also needed.