### PR TITLE
glibc: Add rdepends for glibc-utils

### DIFF
--- a/recipes-debian/glibc/glibc_debian.bbappend
+++ b/recipes-debian/glibc/glibc_debian.bbappend
@@ -11,6 +11,8 @@ RDEPENDS_locales = "glibc perl \
 "
 DESCRIPTION_locales = "locales utils -- locale-gen, update-locale, validlocale"
 
+RDEPENDS_${PN}-utils = "perl"
+
 do_install_append () {
     if ${@bb.utils.contains('IMAGE_INSTALL', "locales", 'true', 'false', d)}; then
         install -d ${D}/${sbindir}


### PR DESCRIPTION
If set following line in conf/local.conf, got a QA error.
IMAGE_INSTALL_append = "locales glibc-utils"

Following error is shown.

```
ERROR: glibc-2.28-r0 do_package_qa: QA Issue: /usr/sbin/validlocale contained in package glibc-utils requires /usr/bin/perl, but no providers found in RDEPENDS_glibc-utils? [file-rdeps]
ERROR: glibc-2.28-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: glibc-2.28-r0 do_package_qa:
ERROR: glibc-2.28-r0 do_package_qa: Function failed: do_package_qa
ERROR: Logfile of failure stored in: /home/masami/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/glibc/2.28-r0/temp/log.do_package_qa.21391
ERROR: Task (/home/masami/emlinux/repos/meta-debian/recipes-debian/glibc/glibc_debian.bb:do_package_qa) failed with exit code '1'
```
