### PR TITLE
cogl: Do not depend PN-dev on empty PN

### DIFF
--- a/recipes-debian/cogl/cogl-1.0_debian.bb
+++ b/recipes-debian/cogl/cogl-1.0_debian.bb
@@ -12,3 +12,5 @@ FILESPATH_append = ":${COREBASE}/meta/recipes-graphics/cogl/cogl-1.0"
 SRC_URI += "file://test-backface-culling.c-fix-may-be-used-uninitialize.patch"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=1b1a508d91d25ca607c83f92f3e31c84"
+
+RDEPENDS_${PN}-dev = "libcogl"


### PR DESCRIPTION
This fixes sdk build warning like below.

  The following packages have unmet dependencies:
   cogl-1.0-dev : Depends: cogl-1.0 (= 1.22.2-r0)
                  Recommends: libcogl-dev but it is not installable
                  Recommends: libcogl-gles2-dev but it is not installable
                  Recommends: libcogl-pango-dev but it is not installable
                  Recommends: libcogl-path-dev but it is not installable
  E: Unable to correct problems, you have held broken packages.

(From Poky rev: f461ae8b4da443e972dee29058a8f2cae8b051c2)