### PR TITLE
systemd-boot: fix: add poky's systemd patch files directory path

### DIFF
--- a/recipes-debian/systemd/systemd-boot_debian.bb
+++ b/recipes-debian/systemd/systemd-boot_debian.bb
@@ -4,7 +4,7 @@
 
 require systemd.inc
 
-FILESEXTRAPATHS =. "${FILE_DIRNAME}/systemd:"
+FILESPATH_append = ":${COREBASE}/meta/recipes-core/systemd/systemd"
 
 DEPENDS = "intltool-native libcap util-linux gnu-efi gperf-native"
 


### PR DESCRIPTION
For non-x86 target, got following warnings because these patches are in
${COREBASE}/meta/recipes-core/systemd/systemd, but recipes file
doesn't append the path. If target is x86 or x86_64, build failed.

```
WARNING: /home/masami/pr-test/repos/meta-debian-extended/recipes-debian/systemd/systemd-boot_debian.bb: Unable to get checksum for systemd-boot SRC_URI entry 0001-Revert-meson-use-an-array-option-for-efi-cc.patch: file could not be found
WARNING: /home/masami/pr-test/repos/meta-debian-extended/recipes-debian/systemd/systemd-boot_debian.bb: Unable to get checksum for systemd-boot SRC_URI entry 0001-Revert-meson-print-EFI-CC-configuration-nicely.patch: file could not be found
WARNING: /home/masami/pr-test/repos/meta-debian-extended/recipes-debian/systemd/systemd-boot_debian.bb: Unable to get checksum for systemd-boot SRC_URI entry 0001-Fix-to-run-efi_cc-and-efi_ld-correctly-when-cross-co.patch: file could not be found
```

Add correct path to be able to read patch files.