### PR TITLE
init-system-helpers: remove man pages

### DIFF
--- a/recipes-debian/init-system-helpers/init-system-helpers_debian.bb
+++ b/recipes-debian/init-system-helpers/init-system-helpers_debian.bb
@@ -26,13 +26,9 @@ do_install() {
 	install -d ${D}${datadir}/dh-systemd
 	install -d ${D}${datadir}/perl5/Debian/Debhelper/Sequence
 	install -d ${D}${datadir}/debhelper
-	install -d ${D}${datadir}/man/man8
-	install -d ${D}${datadir}/man/man1
 
 	#follow debian/dh-systemd.install and debian/init-system-helpers.install
 	install -m 0755 script/* ${D}${bindir}
-	install -m 0644 ${S}/../usr/share/man/man8/* ${D}${datadir}/man/man8
-	install -m 0644 ${S}/../usr/share/man/man1/* ${D}${datadir}/man/man1
 }
 
 ALTERNATIVE_${PN} = "service invoke-rc.d update-rc.d deb-systemd-helper deb-systemd-invoke"


### PR DESCRIPTION
This fixes build error of init-system-helpers.

The man pages are provided in rst format. So, it requires rst2man
command to generate the man pages.
In general, man pages are not important for Yocto systems.
Let's remove the man pages.