### PR TITLE
freetype: Fix brace expansion

### DIFF
--- a/recipes-debian/freetype/freetype_debian.bb
+++ b/recipes-debian/freetype/freetype_debian.bb
@@ -61,5 +61,6 @@ do_debian_unpack_extra_append () {
     fi
 
     # Fix wrong path in debian patches
-    sed -e "s#/ft2docs/#/#g" -i ${S}/debian/patches/{no-web-fonts,hide-donations-information}.patch
+    sed -e "s#/ft2docs/#/#g" -i ${S}/debian/patches/no-web-fonts.patch
+    sed -e "s#/ft2docs/#/#g" -i ${S}/debian/patches/hide-donations-information.patch
 }


### PR DESCRIPTION
Under some environment, This expression does not work correctly:

  path/to/something/{aaa,bbb}.patch

This commit fixes the expression temporary.