### PR TITLE
libnet-libidn-perl: fix build

### DIFF
--- a/recipes-debian/perl/libnet-libidn-perl_debian.bb
+++ b/recipes-debian/perl/libnet-libidn-perl_debian.bb
@@ -5,8 +5,8 @@ LICENSE = "Artistic-1.0 | GPL-1.0+"
 
 LIC_FILES_CHKSUM = "file://debian/copyright;md5=0f6c82cc8795bc88c8b8eb0faf6e6bf9"
 
-DEPENDS += "perl libidn-native"
-RDEPENDS_${PN} += "libidn"
+DEPENDS += "perl libidn"
+RDEPENDS_${PN} += "perl libidn"
 
 inherit debian-package
 require recipes-debian/sources/libnet-libidn-perl.inc
@@ -18,4 +18,9 @@ inherit cpan
 
 BBCLASSEXTEND = "native"
 
-EXTRA_CPANFLAGS = "--with-libidn=${STAGING_LIBDIR_NATIVE} --with-libidn-inc=${STAGING_INCDIR_NATIVE}"
+EXTRA_CPANFLAGS = "--with-libidn=${STAGING_BASELIBDIR} --with-libidn-inc=${STAGING_INCDIR}"
+
+do_configure_prepend() {
+    # skip test to detect libidn or libidn2
+    sed -i -e 's|CheckLibidn($Params{INC}, $Params{LIBS})|1|' ${S}/Makefile.PL
+}


### PR DESCRIPTION
Previously, the test in Makefile.PL uses host's libidn.so. This makes Makefile.PL skip the test.