### PR TITLE
ppp: fix QA issue

### DIFF
--- a/recipes-debian/ppp/ppp_debian.bb
+++ b/recipes-debian/ppp/ppp_debian.bb
@@ -53,6 +53,10 @@ EXTRA_OEMAKE += ' COPTS="${CFLAGS} -I${STAGING_INCDIR}/openssl -I${S}/include"'
 
 do_configure () {
 	oe_runconf
+
+        sed -e '/-I\/usr\/kerberos\/include/ s|-I/usr/kerberos/include||' \
+            -e '/-I\/usr\/include\/openssl/ s|-I/usr/include/openssl|-I${STAGING_INCDIR}/openssl|' \
+            -i ${S}/pppd/Makefile
 }
 
 do_install_append () {


### PR DESCRIPTION
This fixes the following error:
```
ERROR: ppp-2.4.7-r0 do_package_qa: QA Issue: ppp: The compile log indicates that host include and/or library paths were used.
```