### PR TITLE
xml-core: add RDEPENDS_${PN}="perl"

### DIFF
--- a/recipes-debian/xml/xml-core_debian.bb
+++ b/recipes-debian/xml/xml-core_debian.bb
@@ -26,4 +26,4 @@ FILES_${PN} += " \
     /usr/share/xml/* \
 "
 
-RDEPENDS_${PN} = "sgml-base"
+RDEPENDS_${PN} = "perl sgml-base"


### PR DESCRIPTION
This fixes the following error:
```
ERROR: xml-core-0.18+nmu1-r0 do_package_qa: QA Issue:
/usr/sbin/update-xmlcatalog contained in package xml-core requires
/usr/bin/perl, but no providers found in RDEPENDS_xml-core? [file-rdeps]
```