### PR TITLE
Revert "glib-2.0: fix build error of nativesdk"

### DIFF
--- a/recipes-debian/glib-2.0/glib-2.0_debian.bbappend
+++ b/recipes-debian/glib-2.0/glib-2.0_debian.bbappend
@@ -2,13 +2,3 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/glib-2.0:"
 SRC_URI += " \
     file://0001-Do-not-write-bindir-into-pkg-config-files.patch \
 "
-
-do_write_config_append_class-nativesdk() {
-    sed -e "/^c_args/ s|c_args = \[|c_args = \['$(echo ${TOOLCHAIN_OPTIONS} | sed -e 's/^ *//')', |" \
-        -e "/^c_link_args/ s|c_link_args = |c_link_args = \['$(echo ${TOOLCHAIN_OPTIONS} | sed -e 's/^ *//')', |" \
-        -e "/^c_link_args/ s|$|\]|" \
-        -e "/^cpp_args/ s|cpp_args = \[|cpp_args = \['$(echo ${TOOLCHAIN_OPTIONS} | sed -e 's/^ *//')', |" \
-        -e "/^cpp_link_args/ s|cpp_link_args = |cpp_link_args = \['$(echo ${TOOLCHAIN_OPTIONS} | sed -e 's/^ *//')', |" \
-        -e "/^cpp_link_args/ s|$|\]|" \
-        -i ${WORKDIR}/meson.cross
-}


### PR DESCRIPTION
This reverts commit 6dcca509a9825c652ff833f72898078c0fb41ea8.

The following commit in meta-debian fixed root cause.

  meson: Handle strings in cross file args
    - d67a5d65a5ba657100f65dba119ae2ca2a39f6ba