### PR TITLE
haveged: fix: use upstream haveged init scripit

### DIFF
--- a/recipes-debian/haveged/haveged_debian.bb
+++ b/recipes-debian/haveged/haveged_debian.bb
@@ -24,6 +24,7 @@ EXTRA_OECONF = "\
 
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
 PACKAGECONFIG[systemd] = "--enable-init=service.redhat --enable-initdir=${systemd_system_unitdir}, --enable-init=sysv.redhat, systemd"
+PACKAGECONFIG[sysvinit] = "--enable-init=sysv.redhat --enable-initdir=${sysconfdir}/init.d, --enable-init=sysv.redhat, sysvinit"
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME = "haveged"
@@ -40,7 +41,7 @@ do_install_append() {
     fi
 
     install -d ${D}${sysconfdir}/init.d/
-    install -p -m644 ${S}/debian/haveged.init.d ${D}${sysconfdir}/init.d/haveged
+    install -p -m755 ${B}/init.d/haveged ${D}${sysconfdir}/init.d/haveged
 }
 
 MIPS_INSTRUCTION_SET = "mips"


### PR DESCRIPTION
There are two problems. The one is wrong perm has set to
/etc/init.d/haveged script. To run /etc/init.d/haveged, the
perm should have x bit. So change install command option
from -m644 to -m755.

The other is use upstream haveged init script instead of debian's.
Debian package use its own init script(https://sources.debian.org/src/haveged/1.9.1-7/debian/haveged.init.d/)
This scirpt loads /lib/init/vars.sh which is provided by debian
sysvunit-utils package(https://packages.debian.org/buster/arm64/sysvinit-utils/filelist). The sysvunit-util hasn't provided by
meta-deian nor meta-debian-extended yet.
It's okay to use debian's init script when sysvinit-utils package is included in
meta-debian or meta-debian-extended.

* run haveged on systemd env

```
root@qemuarm64:~# PAGER=cat systemctl status haveged
● haveged.service - Entropy daemon using the HAVEGE algorithm
   Loaded: loaded (/lib/systemd/system/haveged.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-12-24 02:03:05 UTC; 48s ago
     Docs: man:haveged(8)
           http://www.issihosts.com/haveged/
 Main PID: 2403 (haveged)
    Tasks: 1 (limit: 531)
   Memory: 3.2M
   CGroup: /system.slice/haveged.service
           └─2403 /usr/sbin/haveged --Foreground --verbose=1

Dec 24 02:03:05 qemuarm64 systemd[1]: Started Entropy daemon using the HAVEGE algorithm.
Dec 24 02:03:07 qemuarm64 haveged[2403]: haveged: ver: 1.9.1; arch: generic; vend: ; build: (gcc 8.3.0 CTV); collect: 128K
Dec 24 02:03:07 qemuarm64 haveged[2403]: haveged: cpu: (VC); data: 16K (D); inst: 16K (D); idx: 11/40; sz: 15528/64688
Dec 24 02:03:07 qemuarm64 haveged[2403]: haveged: tot tests(BA8): A:1/1 B:1/1 continuous tests(B):  last entropy estimate 8.00091
Dec 24 02:03:07 qemuarm64 haveged[2403]: haveged: fills: 0, generated: 0
```

* run haveged on sysvinit env

```
root@qemuarm64:~# /etc/init.d/haveged restart
Stopping haveged: [  OK  ]
Starting haveged: [  OK  ]
root@qemuarm64:~# /etc/init.d/haveged status
haveged (pid 2070) is running...
```
