### PR TITLE
xcb-util: fix conflict with Poky's xcb-util-image

### DIFF
--- a/recipes-debian/xorg-lib/xcb-util_debian.bb
+++ b/recipes-debian/xorg-lib/xcb-util_debian.bb
@@ -13,3 +13,7 @@ DEBIAN_QUILT_PATCHES = ""
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/xcb_aux.c;endline=30;md5=ae305b9c2a38f9ba27060191046a6460 \
                     file://src/xcb_event.h;endline=27;md5=627be355aee59e1b8ade80d5bd90fad9"
+
+do_install_append() {
+        rm -f ${D}${includedir}/xcb/xcb_bitops.h
+}


### PR DESCRIPTION
Adding the meta-qt5 layer and building the qtbase package the following
error occurred:

```
ERROR: qtbase-5.12.6+gitAUTOINC+f0b93f7a4b-r0 do_prepare_recipe_sysroot: The file /usr/include/xcb/xcb_bitops.h is installed by both xcb-util and xcb-util-image, aborting
```

Since the libxcb-image-dev package built from Poky's xcb-util-image recipe
(0.4.0) contains xcb_bitops.h, remove it from the libxcb-util-dev package
built from the xcb-util recipe (0.3.8).

Steps to reproduce:

1. Clone meta-emlinux:
  $ mkdir repos
  $ git clone -b warrior https://github.com/miraclelinux/meta-emlinux.git repos/meta-emlinux
2. Clone meta-qt5:
  $ git clone -b warrior https://github.com/meta-qt5/meta-qt5 repos/meta-qt5
3. Setup build directory:
  $ source repos/meta-emlinux/scripts/setup-emlinux build
4. Add meta-qt5 layer to conf/bblayers.conf:
  $ bitbake-layers add-layer ../repos/meta-qt5
5. Set target machine to conf/local.conf:
  $ echo "MACHINE = \"qemuarm64\"" >> conf/local.conf
6. Build qtbase package:
  $ bitbake qtbase