### PR TITLE
libcheck: fix install error for static library

### DIFF
--- a/recipes-debian/libcheck/libcheck_debian.bb
+++ b/recipes-debian/libcheck/libcheck_debian.bb
@@ -27,6 +27,8 @@ RREPLACES_${PN} = "check (<= 0.9.5)"
 RDEPENDS_${PN} += "gawk"
 RDEPENDS_${PN}_class-native = ""
 
-do_install_append() {
-	cp -f ${D}/usr/lib/libcheck.a ${D}/usr/lib/libcheck_pic.a
+do_debian_patch_prepend() {
+    cd ${DEBIAN_UNPACK_DIR}
+    # remove patch for Debian
+    sed -i -e '/01pkgconfig\.patch/d' ./debian/patches/series
 }


### PR DESCRIPTION
When build libcheck package with deby-tiny distribution, build errors
occured like follows:

```
| cp: cannot stat '/work2/debian-extended/build/tmp/work/aarch64-deby-linux/libcheck/0.10.0-r0/image/usr/lib/libcheck.a': No such file or directory
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_install (log file is located at /work2/debian-extended/build/tmp/work/aarch64-deby-linux/libcheck/0.10.0-r0/temp/log.do_install.31395)
```

This commit fixes the error.