### PR TITLE
nettle: ptest: skip symbols-test if --static-disabled is specified

### DIFF
--- a/recipes-debian/nettle/nettle_debian.bb
+++ b/recipes-debian/nettle/nettle_debian.bb
@@ -46,7 +46,10 @@ do_install_append() {
     oe_multilib_header nettle/nettle-stdint.h nettle/version.h
 }
 
-RDEPENDS_${PN}-ptest += "binutils"
+RDEPENDS_${PN}-ptest += " \
+    ${@bb.utils.contains('DISABLE_STATIC', '--disable-static', '', 'binutils', d)} \
+"
+
 do_install_ptest() {
         install -d ${D}${PTEST_PATH}/testsuite/
         install ${S}/testsuite/gold-bug.txt ${D}${PTEST_PATH}/testsuite/
@@ -54,9 +57,13 @@ do_install_ptest() {
         # tools can be found in PATH, not in ../tools/
         sed -i -e 's|../tools/||' ${D}${PTEST_PATH}/testsuite/*-test
         install ${B}/testsuite/*-test ${D}${PTEST_PATH}/testsuite/
-	install ${B}/version.h ${D}${PTEST_PATH}/
-	install ${B}/libhogweed.a ${D}${PTEST_PATH}/
-	install ${B}/libnettle.a ${D}${PTEST_PATH}/
+        if ${@bb.utils.contains('DISABLE_STATIC', '--disable-static', 'true', 'false', d)}; then
+                rm ${D}${PTEST_PATH}/testsuite/symbols-test
+        else
+                install ${B}/version.h ${D}${PTEST_PATH}/
+                install ${B}/libhogweed.a ${D}${PTEST_PATH}/
+                install ${B}/libnettle.a ${D}${PTEST_PATH}/
+        fi
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The symbols-test checks static libraries (libhogweed.a, libnettle.a), which are not installed if --static-disabled is given. Then we should skip the testcase.
This is necessary to build with meta/conf/distro/include/no-static-libs.inc.