### PR TITLE
Fix x related packaging bugs

### DIFF
--- a/recipes-debian/xorg-app/mkfontdir_debian.bb
+++ b/recipes-debian/xorg-app/mkfontdir_debian.bb
@@ -25,6 +25,8 @@ files."
 RDEPENDS_${PN} += "mkfontscale"
 RDEPENDS_${PN}_class-native += "mkfontscale-native"
 
+# Set command's version instead of using debian package version.
+PV = "1.0.7"
 BBCLASSEXTEND = "native"
 
 LIC_FILES_CHKSUM = "file://mkfontdir/COPYING;md5=b4fcf2b90cadbfc15009b9e124dc3a3f"

--- a/recipes-debian/xorg-app/mkfontscale_debian.bb
+++ b/recipes-debian/xorg-app/mkfontscale_debian.bb
@@ -24,6 +24,8 @@ is used by the mkfontdir program."
 
 DEPENDS = "util-macros-native zlib libfontenc freetype xorgproto"
 
+# Set command's version instead of using debian package version.
+PV = "1.1.3"
 BBCLASSEXTEND = "native"
 
 LIC_FILES_CHKSUM = "file://mkfontscale/COPYING;md5=2e0d129d05305176d1a790e0ac1acb7f"

--- a/recipes-debian/xorg-app/rgb_debian.bb
+++ b/recipes-debian/xorg-app/rgb_debian.bb
@@ -24,9 +24,9 @@ LIC_FILES_CHKSUM = "file://rgb/COPYING;md5=ef598adbe241bd0b0b9113831f6e249a"
 
 FILES_${PN} += "${datadir}/X11"
 
-EXTRA_OECONF += "--host=${BUILD_SYS}"
+EXTRA_OECONF += "--host=${BUILD_SYS} --with-rgb-db-dir=${datadir}/X11/rgb"
 
-TARGET_APP = "xset"
+TARGET_APP = "rgb"
 
 # Set command's version instead of using debian package version.
 PV = "1.0.6"

--- a/recipes-debian/xorg-app/rgb_debian.bb
+++ b/recipes-debian/xorg-app/rgb_debian.bb
@@ -28,6 +28,9 @@ EXTRA_OECONF += "--host=${BUILD_SYS}"
 
 TARGET_APP = "xset"
 
+# Set command's version instead of using debian package version.
+PV = "1.0.6"
+
 do_configure () {
     # cd ${S}/${TARGET_APP}; autoreconf -f -i -s; ./configure ${EXTRA_OECONF}
     cd ${S}/${TARGET_APP}; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-app/xdpyinfo_debian.bb
+++ b/recipes-debian/xorg-app/xdpyinfo_debian.bb
@@ -31,6 +31,8 @@ EXTRA_OECONF = "--disable-xkb"
 EXTRA_OECONF += "--host=${BUILD_SYS}"
 
 TARGET_APP = "xdpyinfo"
+# Set command's version instead of using debian package version.
+PV = "1.3.2"
 
 do_configure () {
     cd ${S}/${TARGET_APP}; autoreconf -f -i -s; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-app/xhost_debian.bb
+++ b/recipes-debian/xorg-app/xhost_debian.bb
@@ -34,6 +34,8 @@ EXTRA_OECONF = " \
 "
 
 TARGET_APP = "xhost"
+# Set command's version instead of using debian package version.
+PV = "1.0.7"
 
 do_configure () {
     cd ${S}/${TARGET_APP}; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-app/xmodmap_debian.bb
+++ b/recipes-debian/xorg-app/xmodmap_debian.bb
@@ -27,6 +27,8 @@ LIC_FILES_CHKSUM = "file://xmodmap/COPYING;md5=272c17e96370e1e74773fa22d9989621"
 EXTRA_OECONF += "--host=${BUILD_SYS}"
 
 TARGET_APP = "xmodmap"
+# Set command's version instead of using debian package version.
+PV = "1.0.9"
 
 do_configure () {
     cd ${S}/${TARGET_APP}; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-app/xrandr_debian.bb
+++ b/recipes-debian/xorg-app/xrandr_debian.bb
@@ -31,6 +31,8 @@ EXTRA_OECONF = " \
 "
 
 TARGET_APP = "xrandr"
+# Set command's version instead of using debian package version.
+PV = "1.5.0"
 
 do_configure () {
     cd ${S}/${TARGET_APP}; autoreconf -f -i -s; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-app/xset_debian.bb
+++ b/recipes-debian/xorg-app/xset_debian.bb
@@ -33,6 +33,8 @@ EXTRA_OECONF = "--disable-xkb --without-fontcache"
 EXTRA_OECONF += "--host=${BUILD_SYS}"
 
 TARGET_APP = "xset"
+# Set command's version instead of using debian package version.
+PV = "1.2.4"
 
 do_configure () {
     cd ${S}/${TARGET_APP}; autoreconf -f -i -s; ./configure ${EXTRA_OECONF}

--- a/recipes-debian/xorg-font/font-util_debian.bb
+++ b/recipes-debian/xorg-font/font-util_debian.bb
@@ -26,6 +26,8 @@ DEPENDS_class-native = "util-macros-native"
 RDEPENDS_${PN} = "mkfontdir mkfontscale encodings"
 RDEPENDS_${PN}_class-native = ""
 
+# Set command's version instead of using debian package version.
+PV = "1.3.1"
 BBCLASSEXTEND = "native"
 
 SYSROOT_DIRS_BLACKLIST_remove = "${datadir}/fonts"


### PR DESCRIPTION
# Purpose of pull request

This PR fixes two kind of packaging bugs. The one is set PV to set correct command version instead of using debian package version. The other is showrgb command doesn't work correctly.

# Test
## How to test

### Check PV

1. bitbake-layers show-recipes

#### showrgb command 

1. Add INSTALL_IMAGE_append += "rgb"
2. build core-image-weston
3. run runqemu qemuarm64 core-image-weston
3. run showrgb command from terminal

## Test result

### Check PV

xdpyinfo
```
xdpyinfo:
  meta-debian-extended 1.3.2
  meta                 1:1.3.2
```
font-util
```
font-util:
  meta-debian-extended 1.3.1
  meta                 1.3.1
```
mkfontdir
```
mkfontdir:
  meta-debian-extended 1.0.7
  meta                 1:1.0.7
```
mkfontscale
```
mkfontscale:
  meta-debian-extended 1.1.3
  meta                 1.1.3
```
rgb
```
rgb:
  meta-debian-extended 1.0.6
  meta                 1:1.0.6
```
xhost
```
xhost:
  meta-debian-extended 1.0.7
  meta                 1:1.0.8
```
xmodmap
```
modmap:
  meta-debian-extended 1.0.9
  meta                 1:1.0.10
```
xrandr
```
xrandr:
  meta-debian-extended 1:1.5.0
  meta                 1:1.5.0
```
xset
```
xset:
  meta-debian-extended 1.2.4
  meta                 1:1.2.4
```

#### showrgb command 

Success to see rgb database.

![showrgb](https://user-images.githubusercontent.com/165052/82643906-558cea00-9c4b-11ea-8212-d9c8c386a0a7.png)



