### PR TITLE
target-sdk-provides-dummy: fix build error of nativesdk

### DIFF
--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -12,3 +12,62 @@ SYSVINIT_SCRIPTS = "${VIRTUAL-RUNTIME_base-utils-hwclock} \
                    "
 
 DUMMYPROVIDES =+ " ${SYSVINIT_SCRIPTS}"
+
+DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'busybox', '\
+		busybox \
+		busybox-dev \
+		busybox-src \
+		', '', d)}"
+
+DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'coreutils', '\
+		coreutils \
+		coreutils-dev \
+		coreutils-src \
+		', '', d)}"
+
+DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'bash', '\
+		bash \
+		bash-dev \
+		bash-src \
+		', '', d)}"
+
+DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'perl', '\
+		perl \
+		perl-dev \
+		perl-src \
+		perl-module-re \
+		perl-module-strict \
+		perl-module-vars \
+		perl-module-text-wrap \
+		libxml-parser-perl \
+		perl-module-bytes \
+		perl-module-carp \
+		perl-module-config \
+		perl-module-constant \
+		perl-module-data-dumper \
+		perl-module-errno \
+		perl-module-exporter \
+		perl-module-file-basename \
+		perl-module-file-compare \
+		perl-module-file-copy \
+		perl-module-file-find \
+		perl-module-file-glob \
+		perl-module-file-path \
+		perl-module-file-stat \
+		perl-module-file-temp \
+		perl-module-getopt-long \
+		perl-module-io-file \
+		perl-module-overload \
+		perl-module-overloading \
+		perl-module-posix \
+		perl-module-thread-queue \
+		perl-module-threads \
+		perl-module-warnings \
+		perl-module-warnings-register \
+		', '', d)}"
+
+DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'pkgconfig', '\
+		pkgconfig \
+		pkgconfig-dev \
+		pkgconfig-src \
+		', '', d)}"


### PR DESCRIPTION
# Purpose of pull request

This PR fix avoids a bug in apt-get specification.If you add coreutils to IMAGE_INSTALL_append and build the SDK you will see the following error.

Error messages:
The following packages have unmet dependencies:
 target-sdk-provides-dummy : Conflicts: coreutils

This kind of error occurs when you add the following packages to IMAGE_INSTALL.
- coreutils
- busybox
- bash
- perl
- pkgconfig

This problem occurs at  target-sdk-provides-dummy, when using package_debian and the IMAGE_INSTALL and DUMMYPROVIDES lists are duplicated.
Removing the duplicate package from DUMMYPROVIDES solves this problem.

# Test
## How to test

Normal build.
```
$ bitbake -e target-sdk-provides-dummy | grep DUMMYPROVIDES
DUMMYPROVIDES=" busybox-hwclock modutils-initscripts init-ifupdown sysvinit busybox-syslog busybox  busybox-dev     busybox-src     coreutils     coreutils-dev     coreutils-src     bash     bash-dev     bash-src     perl     perl-dev     perl-src     perl-module-re     perl-module-strict     perl-module-vars     perl-module-text-wrap     libxml-parser-perl     perl-module-bytes     perl-module-carp     perl-module-config     perl-module-constant     perl-module-data-dumper     perl-module-errno     perl-module-exporter     perl-module-file-basename     perl-module-file-compare     perl-module-file-copy     perl-module-file-find     perl-module-file-glob     perl-module-file-path     perl-module-file-stat     perl-module-file-temp     perl-module-getopt-long     perl-module-io-file     perl-module-overload     perl-module-overloading     perl-module-posix     perl-module-thread-queue     perl-module-threads     perl-module-warnings     perl-module-warnings-register     /bin/sh     /bin/bash     /usr/bin/env     /usr/bin/perl     pkgconfig     pkgconfig-dev     pkgconfig-src "

$ bitbake core-image-minimal
$ bitbake core-image-minimal-sdk -c populate_sdk
```
Successfly

Add following to conf/local.conf
IMAGE_INSTALL_append += " busybox coreutils bash perl pkgconfig"
```
$ bitbake -e target-sdk-provides-dummy | grep DUMMYPROVIDES
DUMMYPROVIDES=" busybox-hwclock  modutils-initscripts init-ifupdown sysvinit busybox-syslog  /bin/sh     /bin/bash     /usr/bin/env     /usr/bin/perl                "
```
Duplicate package has been deleted.
```
$ bitbake core-image-minimal
$ bitbake core-image-minimal-sdk -c populate_sdk
```
Successfly

## Test result
Successful with all build patterns.




