### PR TITLE
iperf2: Fix compilation failure with --disable-ipv6

### DIFF
--- a/recipes-debian/iperf2/iperf2/0001-fix-compile-when-disable-ipv6-is-configured.-Thanks-.patch
+++ b/recipes-debian/iperf2/iperf2/0001-fix-compile-when-disable-ipv6-is-configured.-Thanks-.patch
@@ -1,0 +1,36 @@
+From e7dc021b7f791256ef280bb25a398c03e4433c2a Mon Sep 17 00:00:00 2001
+From: Robert McMahon <rjmcmahon@rjmcmahon.com>
+Date: Tue, 30 Oct 2018 11:50:11 -0700
+Subject: [PATCH] fix compile when --disable-ipv6 is configured.  Thanks to
+ Gaetano Catalli
+
+---
+ src/Listener.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/Listener.cpp b/src/Listener.cpp
+index aca6ca3..f80a058 100644
+--- a/src/Listener.cpp
++++ b/src/Listener.cpp
+@@ -707,6 +707,7 @@ int Listener::L2_setup (void) {
+     // Now optimize packet flow up the raw socket
+     // Establish the flow BPF to forward up only "connected" packets to this raw socket
+     if (l->sa_family == AF_INET6) {
++#ifdef HAVE_IPV6
+ 	struct in6_addr *v6peer = SockAddr_get_in6_addr(&server->peer);
+ 	struct in6_addr *v6local = SockAddr_get_in6_addr(&server->local);
+ 	if (isIPV6(server)) {
+@@ -717,6 +718,10 @@ int Listener::L2_setup (void) {
+ 	    rc = SockAddr_v4_Connect_BPF(server->mSock, (uint32_t) v6local->s6_addr32[3], (uint32_t) v6peer->s6_addr32[3], ((struct sockaddr_in6 *)(l))->sin6_port, ((struct sockaddr_in6 *)(p))->sin6_port);
+ 	    WARN_errno( rc == SOCKET_ERROR, "l2 v4in6 connect ip bpf");
+ 	}
++#else
++	fprintf(stderr, "Unfortunately, IPv6 is not supported on this platform\n");
++	return -1;
++#endif /* HAVE_IPV6 */
+     } else {
+ 	rc = SockAddr_v4_Connect_BPF(server->mSock, ((struct sockaddr_in *)(l))->sin_addr.s_addr, ((struct sockaddr_in *)(p))->sin_addr.s_addr, ((struct sockaddr_in *)(l))->sin_port, ((struct sockaddr_in *)(p))->sin_port);
+ 	WARN_errno( rc == SOCKET_ERROR, "l2 connect ip bpf");
+-- 
+2.17.1
+

--- a/recipes-debian/iperf2/iperf2_debian.bb
+++ b/recipes-debian/iperf2/iperf2_debian.bb
@@ -12,6 +12,10 @@ inherit debian-package
 require recipes-debian/sources/iperf.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/iperf-${PV}"
 
+SRC_URI += "\
+    file://0001-fix-compile-when-disable-ipv6-is-configured.-Thanks-.patch \
+"
+
 inherit autotools pkgconfig
 
 EXTRA_OECONF = "--exec-prefix=${STAGING_DIR_HOST}${layout_exec_prefix}"


### PR DESCRIPTION
# Purpose of pull request
This PR fixes the build error of iperf2 when ipv6 is disabled.

We can reproduce the error by adding the following config to local.conf.
`DISTRO_FEATURES_remove = "ipv6"`

This problem is reported in iperf2 upstream as below.
https://sourceforge.net/p/iperf2/tickets/48/

We backport the corresponding patch from the upstream.

