### PR TITLE
python3-pygobject: Fix native package build error

### DIFF
--- a/recipes-debian/python/python3-pygobject_debian.bb
+++ b/recipes-debian/python/python3-pygobject_debian.bb
@@ -36,7 +36,7 @@ PACKAGECONFIG[cairo] = "-Dpycairo=true,-Dpycairo=false, cairo python3-pycairo, p
 BBCLASSEXTEND = "native"
 PACKAGECONFIG_class-native = ""
 
-do_install_append() {
+do_install_append_class-target() {
   # Temporary workaround to fix following duplicate usr directory error.
   # ERROR: python3-pygobject-3.30.4-r0 do_package: QA Issue: python3-pygobject: Files/directories were installed but not shipped in any package:
   #  /usr/usr/lib/python3.7/site-packages/PyGObject-3.30.4.egg-info


### PR DESCRIPTION




# Purpose of pull request

Building native package fails by following error.

mv: cannot stat
'/work2/emlinux/build/tmp-glibc/work/x86_64-linux/python3-pygobject-native/3.30.4-r0/image/usr/usr/lib/*':
No such file or directory

The do_install_append() need to build target package, but not required when build native package.
So, add _class-target suffix to run do_install_append() when build is
target board.

# Test
## How to test

Build native and target package.

```
# bitbake -f python3-pygobject-native -c cleansstate && bitbake -f python3-pygobject-native
# bitbake -f python3-pygobject-c cleansstate && bitbake -f python3-pygobject
```
Build python3-pygoejct-native and python3-pygobject package should success.

Check pygobject package still work on a target board.


## Test result

build 
```
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f python3-pygobject-native -c cleansstate 2>&1 >/dev/null && bitbake -f python3-pygobject-native 2>&1 > /dev/null ; echo $?
0
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f python3-pygobject -c cleansstate 2>&1 >/dev/null && bitbake -f python3-pygobject 2>&1 > /dev/null ; echo $?
0
```

import and call function on target board. 

```
root@qemuarm64:~# python3 -q
[  201.800313] random: python3: uninitialized urandom read (24 bytes read)
>>> import gi
>>> gi.version_info
(3, 30, 4)
```