### PR TITLE
sqlite3: Include SQL functions for loading extension

### DIFF
--- a/recipes-debian/sqlite3/sqlite3_debian.bbappend
+++ b/recipes-debian/sqlite3/sqlite3_debian.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG += "load-ext"
+PACKAGECONFIG[load-ext] = "--enable-load-extension, --disable-load-extension,"


### PR DESCRIPTION
"--enable-load-extension" is set by default in poky, however in debian,
it seems to be disabled, and set manually by debian/rules.
So add a PACKAGECONFIG entry for this option and enable it.

This patch also fixes the following error.
| $: python2
| ...(snip)...
| >>> import sqlite3
| Traceback (most recent call last):
|   File "<stdin>", line 1, in <module>
|   File "/usr/lib/python2.7/sqlite3/__init__.py", line 24, in <module>
|     from dbapi2 import *
|   File "/usr/lib/python2.7/sqlite3/dbapi2.py", line 28, in <module>
|     from _sqlite3 import *
| ImportError: /usr/lib/python2.7/lib-dynload/_sqlite3.so: undefined symbol: sqlite3_enable_load_extension


# Test

Include python and python-sqlite3 into rootfs.

```
$: cat << EOF >> conf/local.conf
IMAGE_INSTALL_append = " python python-sqlite3"
EOF
$: bitbake core-image-minimal
```

Run qemu, and try following commands:

```
$: runqemu core-image-minimal nographic
...(after boot)...
$: python
>>> import sqlite3
>>>
```

