### PR TITLE
hostapd: Add hostapd package

### DIFF
--- a/recipes-debian/hostapd/hostapd/defconfig
+++ b/recipes-debian/hostapd/hostapd/defconfig
@@ -1,0 +1,148 @@
+# Example hostapd build time configuration
+#
+# This file lists the configuration options that are used when building the
+# hostapd binary. All lines starting with # are ignored. Configuration option
+# lines must be commented out complete, if they are not to be included, i.e.,
+# just setting VARIABLE=n is not disabling that variable.
+#
+# This file is included in Makefile, so variables like CFLAGS and LIBS can also
+# be modified from here. In most cass, these lines should use += in order not
+# to override previous values of the variables.
+
+# Driver interface for Host AP driver
+CONFIG_DRIVER_HOSTAP=y
+
+# Driver interface for wired authenticator
+CONFIG_DRIVER_WIRED=y
+
+# Driver interface for madwifi driver
+#CONFIG_DRIVER_MADWIFI=y
+#CFLAGS += -I../../madwifi # change to the madwifi source directory
+
+# Driver interface for Prism54 driver
+CONFIG_DRIVER_PRISM54=y
+
+# Driver interface for drivers using the nl80211 kernel interface
+CONFIG_DRIVER_NL80211=y
+CONFIG_LIBNL32=y
+# driver_nl80211.c requires a rather new libnl (version 1.1) which may not be
+# shipped with your distribution yet. If that is the case, you need to build
+# newer libnl version and point the hostapd build to use it.
+#LIBNL=/usr/src/libnl
+#CFLAGS += -I$(LIBNL)/include
+#LIBS += -L$(LIBNL)/lib
+
+# Driver interface for FreeBSD net80211 layer (e.g., Atheros driver)
+#CONFIG_DRIVER_BSD=y
+#CFLAGS += -I/usr/local/include
+#LIBS += -L/usr/local/lib
+
+# Driver interface for no driver (e.g., RADIUS server only)
+#CONFIG_DRIVER_NONE=y
+
+# IEEE 802.11F/IAPP
+CONFIG_IAPP=y
+
+# WPA2/IEEE 802.11i RSN pre-authentication
+CONFIG_RSN_PREAUTH=y
+
+# PeerKey handshake for Station to Station Link (IEEE 802.11e DLS)
+CONFIG_PEERKEY=y
+
+# IEEE 802.11w (management frame protection)
+# This version is an experimental implementation based on IEEE 802.11w/D1.0
+# draft and is subject to change since the standard has not yet been finalized.
+# Driver support is also needed for IEEE 802.11w.
+#CONFIG_IEEE80211W=y
+
+# Integrated EAP server
+CONFIG_EAP=y
+
+# EAP-MD5 for the integrated EAP server
+CONFIG_EAP_MD5=y
+
+# EAP-TLS for the integrated EAP server
+CONFIG_EAP_TLS=y
+
+# EAP-MSCHAPv2 for the integrated EAP server
+CONFIG_EAP_MSCHAPV2=y
+
+# EAP-PEAP for the integrated EAP server
+CONFIG_EAP_PEAP=y
+
+# EAP-GTC for the integrated EAP server
+CONFIG_EAP_GTC=y
+
+# EAP-TTLS for the integrated EAP server
+CONFIG_EAP_TTLS=y
+
+# EAP-SIM for the integrated EAP server
+#CONFIG_EAP_SIM=y
+
+# EAP-AKA for the integrated EAP server
+#CONFIG_EAP_AKA=y
+
+# EAP-AKA' for the integrated EAP server
+# This requires CONFIG_EAP_AKA to be enabled, too.
+#CONFIG_EAP_AKA_PRIME=y
+
+# EAP-PAX for the integrated EAP server
+#CONFIG_EAP_PAX=y
+
+# EAP-PSK for the integrated EAP server (this is _not_ needed for WPA-PSK)
+#CONFIG_EAP_PSK=y
+
+# EAP-SAKE for the integrated EAP server
+#CONFIG_EAP_SAKE=y
+
+# EAP-GPSK for the integrated EAP server
+#CONFIG_EAP_GPSK=y
+# Include support for optional SHA256 cipher suite in EAP-GPSK
+#CONFIG_EAP_GPSK_SHA256=y
+
+# EAP-FAST for the integrated EAP server
+# Note: Default OpenSSL package does not include support for all the
+# functionality needed for EAP-FAST. If EAP-FAST is enabled with OpenSSL,
+# the OpenSSL library must be patched (openssl-0.9.9-session-ticket.patch)
+# to add the needed functions.
+#CONFIG_EAP_FAST=y
+
+# Wi-Fi Protected Setup (WPS)
+CONFIG_WPS=y
+# Enable UPnP support for external WPS Registrars
+#CONFIG_WPS_UPNP=y
+
+# EAP-IKEv2
+#CONFIG_EAP_IKEV2=y
+
+# Trusted Network Connect (EAP-TNC)
+#CONFIG_EAP_TNC=y
+
+# PKCS#12 (PFX) support (used to read private key and certificate file from
+# a file that usually has extension .p12 or .pfx)
+CONFIG_PKCS12=y
+
+# RADIUS authentication server. This provides access to the integrated EAP
+# server from external hosts using RADIUS.
+CONFIG_RADIUS_SERVER=y
+
+# Build IPv6 support for RADIUS operations
+CONFIG_IPV6=y
+
+# IEEE Std 802.11r-2008 (Fast BSS Transition)
+#CONFIG_IEEE80211R=y
+
+# Use the hostapd's IEEE 802.11 authentication (ACL), but without
+# the IEEE 802.11 Management capability (e.g., madwifi or FreeBSD/net80211)
+CONFIG_DRIVER_RADIUS_ACL=y
+
+# IEEE 802.11n (High Throughput) support
+CONFIG_IEEE80211N=y
+
+# IEEE 802.11ac (Very High Throughput) support
+CONFIG_IEEE80211AC=y
+
+# Remove debugging code that is printing out debug messages to stdout.
+# This can be used to reduce the size of the hostapd considerably if debugging
+# code is not needed.
+#CONFIG_NO_STDOUT_DEBUG=y

--- a/recipes-debian/hostapd/hostapd/hostapd.service
+++ b/recipes-debian/hostapd/hostapd/hostapd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hostapd IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/hostapd.pid
+ExecStart=@SBINDIR@/hostapd @SYSCONFDIR@/hostapd.conf -P /run/hostapd.pid -B
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-debian/hostapd/hostapd/init
+++ b/recipes-debian/hostapd/hostapd/init
@@ -1,0 +1,58 @@
+#!/bin/sh
+DAEMON=/usr/sbin/hostapd
+NAME=hostapd
+DESC="HOSTAP Daemon"
+ARGS="/etc/hostapd.conf -B"
+
+test -f $DAEMON || exit 0
+
+set -e
+
+# source function library
+. /etc/init.d/functions
+
+delay_stop() {
+	count=0
+	while [ $count -lt 9 ] ; do
+	        if pidof $DAEMON >/dev/null; then
+	                sleep 1
+	        else
+	                return 0
+	        fi
+		count=`expr $count + 1`
+	done
+	echo "Failed to stop $DESC."
+	return 1
+}
+
+case "$1" in
+    start)
+	echo -n "Starting $DESC: "
+	start-stop-daemon -S -x $DAEMON -- $ARGS
+	echo "$NAME."
+	;;
+    stop)
+	echo -n "Stopping $DESC: "
+	start-stop-daemon -K --oknodo -x $DAEMON
+	echo "$NAME."
+	;;
+    restart)
+	$0 stop
+	delay_stop && $0 start
+	;;
+    reload)
+	echo -n "Reloading $DESC: "
+	killall -HUP $(basename ${DAEMON})
+	echo "$NAME."
+	;;
+    status)
+	status $DAEMON
+	exit $?
+	;;
+    *)
+	echo "Usage: $0 {start|stop|restart|reload|status}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/recipes-debian/hostapd/hostapd_debian.bb
+++ b/recipes-debian/hostapd/hostapd_debian.bb
@@ -1,0 +1,54 @@
+# base recipe meta-oe/recipes-connectivity/hostapd/hostapd_2.9.bb
+# base branch: master
+# base commit: 589aa162cead42acdd7e8dbd7c0243b95e341f19
+
+SUMMARY = "User space daemon for extended IEEE 802.11 management"
+HOMEPAGE = "http://w1.fi/hostapd/"
+SECTION = "kernel/userland"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://hostapd/README;md5=1ec986bec88070e2a59c68c95d763f89"
+
+DEPENDS = "libnl openssl"
+
+BPN = "wpa"
+inherit debian-package
+require recipes-debian/sources/wpa.inc
+
+
+FILESPATH_append = ":${THISDIR}/${PN}:"
+SRC_URI += " \
+    file://defconfig \
+    file://init \
+    file://hostapd.service \
+"
+
+inherit update-rc.d systemd pkgconfig 
+
+CONFLICT_DISTRO_FEATURES = "openssl-no-weak-ciphers"
+
+INITSCRIPT_NAME = "hostapd"
+
+SYSTEMD_SERVICE_${PN} = "hostapd.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"
+
+do_configure_append() {
+    install -m 0644 ${WORKDIR}/defconfig ${B}/${PN}/.config
+}
+
+do_compile() {
+    export CFLAGS="-MMD -O2 -Wall -g"
+    export EXTRA_CFLAGS="${CFLAGS}"
+    cd ${B}/${PN} ; make V=1
+}
+
+do_install() {
+    install -d ${D}${sbindir} ${D}${sysconfdir}/init.d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${B}/${PN}/hostapd.conf ${D}${sysconfdir}
+    install -m 0755 ${B}/${PN}/hostapd ${D}${sbindir}
+    install -m 0755 ${B}/${PN}/hostapd_cli ${D}${sbindir}
+    install -m 755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/hostapd
+    install -m 0644 ${WORKDIR}/hostapd.service ${D}${systemd_unitdir}/system/
+    sed -i -e 's,@SBINDIR@,${sbindir},g' -e 's,@SYSCONFDIR@,${sysconfdir},g' ${D}${systemd_unitdir}/system/hostapd.service
+}
+
+CONFFILES_${PN} += "${sysconfdir}/hostapd.conf"


### PR DESCRIPTION
# Purpose of pull request
This PR adds hostapd package to support wireless feature..
Recipe is based on meta-oe's.

Tested on raspberry pi 3b+. Access from macOS Big Sur to rpi3 by wpa2.

# Test
## How to test

1. prepare hostapd.conf

Used following setting.

```
--- hostapd.conf.orig	2021-03-12 13:39:37.650391418 +0900
+++ hostapd.conf.new	2021-03-12 13:39:37.627391266 +0900
@@ -25,6 +25,7 @@
 # Use driver=none if building hostapd as a standalone RADIUS server that does
 # not control any wireless/wired driver.
 # driver=hostap
+driver=nl80211
 
 # Driver interface parameters (mainly for development testing use)
 # driver_params=<params>
@@ -85,7 +86,7 @@
 ##### IEEE 802.11 related configuration #######################################
 
 # SSID to be used in IEEE 802.11 management frames
-ssid=test
+ssid=rpi3bap
 # Alternative formats for configuring SSID
 # (double quoted string, hexdump, printf-escaped string)
 #ssid2="test"
@@ -101,6 +102,7 @@
 # These two octets are used as the first two octets of the Country String
 # (dot11CountryString)
 #country_code=US
+country_code=JP
 
 # The third octet of the Country String (dot11CountryString)
 # This parameter is used to set the third octet of the country string.
@@ -294,7 +296,8 @@
 # Bit fields of allowed authentication algorithms:
 # bit 0 = Open System Authentication
 # bit 1 = Shared Key Authentication (requires WEP)
-auth_algs=3
+#auth_algs=3
+auth_algs=1
 
 # Send empty SSID in beacons and ignore probe request frames that do not
 # specify full SSID, i.e., require stations to know SSID.
@@ -1314,6 +1317,7 @@
 # In other words, for WPA3, wpa=2 is used the configuration (and
 # wpa_key_mgmt=SAE for WPA3-Personal instead of wpa_key_mgmt=WPA-PSK).
 #wpa=2
+wpa=2
 
 # WPA pre-shared keys for WPA-PSK. This can be either entered as a 256-bit
 # secret in hex format (64 hex digits), wpa_psk, or as an ASCII passphrase
@@ -1323,6 +1327,7 @@
 # wpa_passphrase (dot11RSNAConfigPSKPassPhrase)
 #wpa_psk=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 #wpa_passphrase=secret passphrase
+wpa_passphrase=<yourpassword>
 
 # Optionally, WPA PSKs can be read from a separate text file (containing list
 # of (PSK,MAC address) pairs. This allows more than one PSK to be configured.
@@ -1361,6 +1366,7 @@
 # OSEN = Hotspot 2.0 online signup with encryption
 # (dot11RSNAConfigAuthenticationSuitesTable)
 #wpa_key_mgmt=WPA-PSK WPA-EAP
+wpa_key_mgmt=WPA-PSK
 
 # Set of accepted cipher suites (encryption algorithms) for pairwise keys
 # (unicast packets). This is a space separated list of algorithms:
```

2. restart hostapd or reboot

3. access to the AP from other PC

## Test result

On mac

Enter passphrase

![sc1](https://user-images.githubusercontent.com/165052/110894497-53f7f400-833b-11eb-997f-0dfa915e0d4b.png)

Connected
![sc2](https://user-images.githubusercontent.com/165052/110894547-65410080-833b-11eb-91ac-1475c6a17856.png)


On raspberry pi

check /var/log/message



```
Mar 12 03:33:06 raspberrypi3-64 daemon.info hostapd: wlan0: STA <mac address> IEEE 802.11: associated
Mar 12 03:33:06 raspberrypi3-64 daemon.info hostapd: wlan0: STA <mac address> RADIUS: starting accounting session C4BD01B328F5C809
Mar 12 03:33:06 raspberrypi3-64 daemon.info hostapd: wlan0: STA <mac address> WPA: pairwise key handshake completed (RSN)
Mar 12 03:33:53 raspberrypi3-64 daemon.info hostapd: wlan0: STA <mac address> IEEE 802.11: disassociated

```



