### PR TITLE
doc: Change meta-debian's branch name

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Dependencies
 ============
 
   URI: https://github.com/meta-debian/meta-debian.git
-  branch: master
+  branch: warrior
 
 Patches
 =======


### PR DESCRIPTION
The warrior branch depends on meta-debian's warrior branch.

