### PR TITLE
bluez5: Add y2038 related patch

### DIFF
--- a/recipes-debian/bluez5/bluez5_debian.bb
+++ b/recipes-debian/bluez5/bluez5_debian.bb
@@ -18,6 +18,7 @@ SRC_URI += "\
     file://0001-test-gatt-Fix-hung-issue.patch \
     file://0001-Makefile.am-Fix-a-race-issue-for-tools.patch \
     file://CVE-2018-10910.patch \
+    file://tools_Fix_build_after_y2038_changes_in_glibc.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "bluez5"

--- a/recipes-debian/bluez5/files/tools_Fix_build_after_y2038_changes_in_glibc.patch
+++ b/recipes-debian/bluez5/files/tools_Fix_build_after_y2038_changes_in_glibc.patch
@@ -1,0 +1,65 @@
+From f36f71f60b1e68c0f12e615b9b128d089ec3dd19 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Fri, 7 Jun 2019 09:51:33 +0200
+Subject: tools: Fix build after y2038 changes in glibc
+
+The 32-bit SIOCGSTAMP has been deprecated. Use the deprecated name
+to fix the build.
+---
+ tools/l2test.c | 6 +++++-
+ tools/rctest.c | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+(limited to 'tools')
+
+diff --git a/tools/l2test.c b/tools/l2test.c
+index e755ac881..e787c2ce2 100644
+--- a/tools/l2test.c
++++ b/tools/l2test.c
+@@ -55,6 +55,10 @@
+ #define BREDR_DEFAULT_PSM	0x1011
+ #define LE_DEFAULT_PSM		0x0080
+ 
++#ifndef SIOCGSTAMP_OLD
++#define SIOCGSTAMP_OLD SIOCGSTAMP
++#endif
++
+ /* Test modes */
+ enum {
+ 	SEND,
+@@ -907,7 +911,7 @@ static void recv_mode(int sk)
+ 			if (timestamp) {
+ 				struct timeval tv;
+ 
+-				if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
++				if (ioctl(sk, SIOCGSTAMP_OLD, &tv) < 0) {
+ 					timestamp = 0;
+ 					memset(ts, 0, sizeof(ts));
+ 				} else {
+diff --git a/tools/rctest.c b/tools/rctest.c
+index 94490f462..bc8ed875d 100644
+--- a/tools/rctest.c
++++ b/tools/rctest.c
+@@ -50,6 +50,10 @@
+ 
+ #include "src/shared/util.h"
+ 
++#ifndef SIOCGSTAMP_OLD
++#define SIOCGSTAMP_OLD SIOCGSTAMP
++#endif
++
+ /* Test modes */
+ enum {
+ 	SEND,
+@@ -505,7 +509,7 @@ static void recv_mode(int sk)
+ 			if (timestamp) {
+ 				struct timeval tv;
+ 
+-				if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
++				if (ioctl(sk, SIOCGSTAMP_OLD, &tv) < 0) {
+ 					timestamp = 0;
+ 					memset(ts, 0, sizeof(ts));
+ 				} else {
+-- 
+cgit 1.2.3-1.el7
+


### PR DESCRIPTION
# Purpose of pull request

Import y2038 problem related  fix patch from bluez5 upstream.

# Test
## How to test

### 1. build against linux 5.10

1. Setup meta-emlinux layer.
2. Add  following values to local.conf

```
DISTRO = "emlinux-k510"
IMAGE_INSTALL_append = " bluez5 "
```
3. build bluz5

### 2. build against linux 4.19

1. Setup meta-emlinux layer.
2. Add  following values to local.conf

```
IMAGE_INSTALL_append = " bluez5 "
```
3. build bluz5

## Test result

linux 5.10

```
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f bluez5 
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2330 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.3"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 = "warrior:c8c383d958807b991e31d22f612ba2a81a3860a4"
meta-debian          = "warrior:2caf6c5cc97982ca335f4693cc8ccfedb71bf81c"
meta-debian-extended = "bluez5-add-y2038-fix-patch:70cefb817171dba7fa159f087076f827548c201b"
meta-emlinux         = "warrior:a210f80254582f9161a89b532f3e87959d3a27cf"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-build/../repos/meta-debian-extended/recipes-debian/bluez5/bluez5_debian.bb, do_build                                                               | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-build/../repos/meta-debian-extended/recipes-debian/bluez5/bluez5_debian.bb.do_build is tainted from a forced run                                                                       | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 415 Found 0 Missed 415 Current 141 (0% match, 25% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2495 tasks of which 1795 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

linux 4.19

```
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f bluez5 
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2330 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.3"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 = "warrior:c8c383d958807b991e31d22f612ba2a81a3860a4"
meta-debian          = "warrior:2caf6c5cc97982ca335f4693cc8ccfedb71bf81c"
meta-debian-extended = "bluez5-add-y2038-fix-patch:70cefb817171dba7fa159f087076f827548c201b"
meta-emlinux         = "warrior:a210f80254582f9161a89b532f3e87959d3a27cf"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-build/../repos/meta-debian-extended/recipes-debian/bluez5/bluez5_debian.bb, do_build                                                               | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-build/../repos/meta-debian-extended/recipes-debian/bluez5/bluez5_debian.bb.do_build is tainted from a forced run                                                                       | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 434 Found 0 Missed 434 Current 120 (0% match, 21% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2476 tasks of which 1504 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```



