### PR TITLE
add checking if removing directory (for workaround) exists.

### DIFF
--- a/recipes-debian/python/python3-pygobject_debian.bb
+++ b/recipes-debian/python/python3-pygobject_debian.bb
@@ -44,8 +44,10 @@ do_install_append_class-target() {
   #  /usr/usr/lib/python3.7/site-packages/pygtkcompat
   #  /usr/usr/lib/python3.7/site-packages/pygtkcompat/pygtkcompat.py
   #  /usr/usr/lib/python3.7/site-packages/pygtkcompat/generictreemodel.py
-  mv ${D}/usr/usr/lib/* ${D}/usr/lib/.
-  rm -fr ${D}/usr/usr
+  if [ -d ${D}/usr/usr/lib ]; then
+    mv ${D}/usr/usr/lib/* ${D}/usr/lib/.
+    rm -fr ${D}/usr/usr
+  fi
 
   # Workaround for the conflict with pycairo
   rm -fr \


### PR DESCRIPTION
without checking if the directory exists or not, python3-pygobject-native
is not buildable.

# Purpose of pull request

currently, building python3-pygobject-native is broken. this patch make it buildable.

# Test
## How to test

check both two targets are buildable.

bitbake python3-pygobject
bitbake python3-pygobject-native



