### PR TITLE
edac-utils: Fix edac sysvinit script

### DIFF
--- a/recipes-debian/edac-utils/edac-utils_debian.bb
+++ b/recipes-debian/edac-utils/edac-utils_debian.bb
@@ -24,6 +24,7 @@ FILES_${PN} += "\
 
 SRC_URI += " \
     file://edac.service \
+	file://edac.init \
 "
 
 inherit autotools-brokensep
@@ -50,6 +51,9 @@ do_install_append() {
 	install -d ${D}${systemd_unitdir}/system
 	install -m 644 ${WORKDIR}/edac.service ${D}/${systemd_unitdir}/system
 	sed -i -e 's,@SBINDIR@,${sbindir},g' ${D}/${systemd_unitdir}/system/edac.service
+
+    # override debian version of init sctipt
+	install -m 755 ${WORKDIR}/edac.init ${D}/${sysconfdir}/init.d/edac
 }
 
 SYSTEMD_SERVICE_${PN} = "edac.service"

--- a/recipes-debian/edac-utils/files/edac.init
+++ b/recipes-debian/edac-utils/files/edac.init
@@ -1,0 +1,120 @@
+#!/bin/sh
+###############################################################################
+# $Id$
+###############################################################################
+# Copyright (C) 2006-2007 The Regents of the University of California.
+# Produced at Lawrence Livermore National Laboratory.
+# Written by Mark Grondona <mgrondona@llnl.gov>
+# UCRL-CODE-230739.
+###############################################################################
+# chkconfig:      345 40 60
+###############################################################################
+### BEGIN INIT INFO
+# Provides:       edac
+# Required-Start: $named $time
+# Default-Start:  3 5
+# Default-Stop:   0 1 2 6
+# Description:    Initialize EDAC drivers for machine hardware
+### END INIT INFO
+###############################################################################
+
+unset SERVICE
+
+SERVICE="edac"
+
+prefix="/usr"
+exec_prefix="/usr"
+sbindir="/usr/sbin"
+sysconfdir="/usr/sbin"
+edac_ctl="$sbindir/edac-ctl"
+
+PATH=/sbin:/usr/sbin:/usr/local/sbin:/bin:/usr/bin:/usr/local/bin
+STATUS=0
+
+###############################################################################
+
+# Don't need to source /etc/init.d/functions at this time
+
+# Read configuration to see if we need to load 
+#  EDAC_DRIVER 
+# 
+for dir in "$sysconfdir/default" "$sysconfdir/sysconfig"; do
+  [ -f "$dir/$SERVICE" ] && . "$dir/$SERVICE"
+done
+
+
+###############################################################################
+
+service_start ()
+{
+# Start the service.  Required by LSB.
+#
+# Assume that if EDAC_DRIVER is not set, then EDAC is configured
+#  automatically, thus return successfully, but don't do anything.
+#
+  if [ -n "$EDAC_DRIVER" ]; then
+     echo -n "Starting ${SERVICE}: "
+     modprobe $EDAC_DRIVER
+     STATUS=$?
+     case $STATUS in 
+       0) echo success ;;
+       5) echo No EDAC support for this hardware. ;;
+       *) echo failure ;;
+     esac
+  fi
+  echo -n "Loading ${SERVICE} DIMM labels: "
+  $edac_ctl --register-labels --quiet
+  STATUS=$?
+  case $STATUS in
+   0) echo success ;;
+   *) echo failure ;;
+  esac
+}
+
+###############################################################################
+
+service_stop ()
+{
+  echo -n "Disabling ${SERVICE}: "
+  if [ -n "$EDAC_DRIVER" ]; then
+    modprobe -r $EDAC_DRIVER
+    STATUS=$?
+    [ $STATUS -eq 0 ] && echo success || echo failure
+  else
+    echo "Not supported for this configuration."
+    STATUS=6
+  fi
+}
+
+###############################################################################
+
+service_status ()
+{
+# Print the current status of the service.  Required by LSB.
+#
+  edac-ctl --status
+  STATUS=0
+}
+
+###############################################################################
+
+STATUS=4
+
+case "$1" in
+  start)
+    service_start
+    ;;
+  stop)
+    service_stop
+    ;;
+  status)
+    service_status
+    ;;
+  *)
+    COMMANDS="start|stop|status"
+    echo "Usage: $0 {${COMMANDS}}"
+    exit 2
+    ;;
+esac
+
+exit $STATUS


### PR DESCRIPTION

# Purpose of pull request

Debian version of init script require its own helper function library
which doesn't exist in meta-debian/meta-debian-extended so use upstream
version of init script.

debian version of script show following error.
root@ls1046ardb:/lib/systemd/system# /etc/init.d/edac status
/etc/init.d/edac: .: line 52: can't open '/lib/init/vars.sh': No such
file or directory
# Test
## How to test

Run following command from console

```
# /etc/init.d/edac status
```

## Test result

```
ls1046ardb login: root
root@ls1046ardb:~# /etc/init.d/edac status
edac-ctl: drivers are loaded.
```

It shouldn't print an error message.




