### PR TITLE
python3-pygobject: Use specific py3cairo version

### DIFF
--- a/recipes-debian/python/python3-pygobject/pygobject-use-specific-py3cairo-version.patch
+++ b/recipes-debian/python/python3-pygobject/pygobject-use-specific-py3cairo-version.patch
@@ -1,0 +1,8 @@
+--- pygobject-3.30.4/subprojects/pycairo.wrap	2018-11-26 07:06:50.000000000 +0900
++++ pygobject-3.30.4.new/subprojects/pycairo.wrap	2022-03-08 14:55:04.364885567 +0900
+@@ -1,4 +1,4 @@
+ [wrap-git]
+ directory=pycairo
+ url=https://github.com/pygobject/pycairo.git
+-revision=master
++revision=v1.20.1

--- a/recipes-debian/python/python3-pygobject_debian.bb
+++ b/recipes-debian/python/python3-pygobject_debian.bb
@@ -18,6 +18,7 @@ DEPENDS += "python3 glib-2.0"
 SRCNAME="pygobject"
 SRC_URI += " \
     file://0001-Rebase-Do-not-build-tests.patch \
+    file://pygobject-use-specific-py3cairo-version.patch \
 "
 
 UNKNOWN_CONFIGURE_WHITELIST = "introspection"


### PR DESCRIPTION
# Purpose of pull request

python3-pygobject downloads pycairo pacakge during its build process.
It always gets master branch.

However, pycairo project recently updated required meson version to
0.53.0. The result is we failed to build python3-pygobject package
because meta-debian uses 0.49.2.

Therefore, we use specific version for python3-pyboject.
The v1.20.1 is the latest version which can build with meson 0.49.2.

# Test
## How to test

Build and run core-image-weston. Building core-image-weston builds python3-pygobject so it easy way to test.

## Test result

Build result

```
masami@ubuntu1804:~/emlinux/qemuarm64-emlinux$ rm -fr bitbake-cookerdaemon.log  cache/ sstate-cache/ tmp-glibc/
masami@ubuntu1804:~/emlinux/qemuarm64-emlinux$ bitbake -f core-image-weston
Parsing recipes: 100% |########################################################################################################################################################################################################| Time: 0:00:38
Parsing of 1339 .bb files complete (0 cached, 1339 parsed). 2359 targets, 77 skipped, 4 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:4336f145b0aa649fcda1a28e762df0a4e5590e81"
meta-debian-extended = "fix-pygobject-build-error:188596aadbbf35fd147595e534a307c45a05acfc"
meta-emlinux         = "warrior:dc7ea175c2520d63023da8c411e5255fef4f7110"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-graphics/images/core-image-weston.bb, do_build                                                                  | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-graphics/images/core-image-weston.bb.do_build is tainted from a forced run                                                                          | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:02
Sstate summary: Wanted 1562 Found 0 Missed 1562 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5136 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.

```

Graphic works fine.


![Screenshot from 2022-03-08 18-55-04](https://user-images.githubusercontent.com/165052/157213451-f590c2a7-09ca-4df0-b9eb-92c236e01822.png)

