### PR TITLE
openssl: Fix ptest failure caused by certificate expiration

### DIFF
--- a/recipes-debian/openssl/files/pr-18446-Update-expired-SCT-certificates.patch
+++ b/recipes-debian/openssl/files/pr-18446-Update-expired-SCT-certificates.patch
@@ -1,0 +1,208 @@
+From 590d9bff7e9682973e25b53493388dc6cbed7360 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Wed, 1 Jun 2022 12:47:44 +0200
+Subject: [PATCH 1/2] Update expired SCT certificates
+
+---
+ test/certs/embeddedSCTs1-key.pem        | 38 ++++++++++++++++---------
+ test/certs/embeddedSCTs1.pem            | 35 ++++++++++++-----------
+ test/certs/embeddedSCTs1.sct            | 12 ++++----
+ test/certs/embeddedSCTs1_issuer-key.pem | 15 ++++++++++
+ test/certs/embeddedSCTs1_issuer.pem     | 30 +++++++++----------
+ 5 files changed, 79 insertions(+), 51 deletions(-)
+ create mode 100644 test/certs/embeddedSCTs1_issuer-key.pem
+
+diff --git a/test/certs/embeddedSCTs1-key.pem b/test/certs/embeddedSCTs1-key.pem
+index e3e66d55c510..28dd206dbe8d 100644
+--- a/test/certs/embeddedSCTs1-key.pem
++++ b/test/certs/embeddedSCTs1-key.pem
+@@ -1,15 +1,27 @@
+ -----BEGIN RSA PRIVATE KEY-----
+-MIICWwIBAAKBgQC+75jnwmh3rjhfdTJaDB0ym+3xj6r015a/BH634c4VyVui+A7k
+-WL19uG+KSyUhkaeb1wDDjpwDibRc1NyaEgqyHgy0HNDnKAWkEM2cW9tdSSdyba8X
+-EPYBhzd+olsaHjnu0LiBGdwVTcaPfajjDK8VijPmyVCfSgWwFAn/Xdh+tQIDAQAB
+-AoGAK/daG0vt6Fkqy/hdrtSJSKUVRoGRmS2nnba4Qzlwzh1+x2kdbMFuaOu2a37g
+-PvmeQclheKZ3EG1+Jb4yShwLcBCV6pkRJhOKuhvqGnjngr6uBH4gMCjpZVj7GDMf
+-flYHhdJCs3Cz/TY0wKN3o1Fldil2DHR/AEOc1nImeSp5/EUCQQDjKS3W957kYtTU
+-X5BeRjvg03Ug8tJq6IFuhTFvUJ+XQ5bAc0DmxAbQVKqRS7Wje59zTknVvS+MFdeQ
+-pz4dGuV7AkEA1y0X2yarIls+0A/S1uwkvwRTIkfS+QwFJ1zVya8sApRdKAcidIzA
+-b70hkKLilU9+LrXg5iZdFp8l752qJiw9jwJAXjItN/7mfH4fExGto+or2kbVQxxt
+-9LcFNPc2UJp2ExuL37HrL8YJrUnukOF8KJaSwBWuuFsC5GwKP4maUCdfEQJAUwBR
+-83c3DEmmMRvpeH4erpA8gTyzZN3+HvDwhpvLnjMcvBQEdnDUykVqbSBnxrCjO+Fs
+-n1qtDczWFVf8Cj2GgQJAQ14Awx32Cn9sF+3M+sEVtlAf6CqiEbkYeYdSCbsplMmZ
+-1UoaxiwXY3z+B7epsRnnPR3KaceAlAxw2/zQJMFNOQ==
++MIIEpQIBAAKCAQEAuIjpA4/iCpDA2mjywI5zG6IBX6bNcRQYDsB7Cv0VonNXtJBw
++XxMENP4jVpvEmWpJ5iMBknGHV+XWBkngYapczIsY4LGn6aMU6ySABBVQpNOQSRfT
++48xGGPR9mzOBG/yplmpFOVq1j+b65lskvAXKYaLFpFn3oY/pBSdcCNBP8LypVXAJ
++b3IqEXsBL/ErgHG9bgIRP8VxBAaryCz77kLzAXkfHL2LfSGIfNONyEKB3xI94S4L
++eouOSoWL1VkEfJs87vG4G5xoXw3KOHyiueQUUlMnu8p+Bx0xPVKPEsLje3R9k0rG
++a5ca7dXAn9UypKKp25x4NXpnjGX5txVEYfNvqQIDAQABAoIBAE0zqhh9Z5n3+Vbm
++tTht4CZdXqm/xQ9b0rzJNjDgtN5j1vuJuhlsgUQSVoJzZIqydvw7BPtZV8AkPagf
++3Cm/9lb0kpHegVsziRrfCFes+zIZ+LE7sMAKxADIuIvnvkoRKHnvN8rI8lCj16/r
++zbCD06mJSZp6sSj8ZgZr8wsU63zRGt1TeGM67uVW4agphfzuKGlXstPLsSMwknpF
++nxFS2TYbitxa9oH76oCpEk5fywYsYgUP4TdzOzfVAgMzNSu0FobvWl0CECB+G3RQ
++XQ5VWbYkFoj5XbE5kYz6sYHMQWL1NQpglUp+tAQ1T8Nca0CvbSpD77doRGm7UqYw
++ziVQKokCgYEA6BtHwzyD1PHdAYtOcy7djrpnIMaiisSxEtMhctoxg8Vr2ePEvMpZ
++S1ka8A1Pa9GzjaUk+VWKWsTf+VkmMHGtpB1sv8S7HjujlEmeQe7p8EltjstvLDmi
++BhAA7ixvZpXXjQV4GCVdUVu0na6gFGGueZb2FHEXB8j1amVwleJj2lcCgYEAy4f3
++2wXqJfz15+YdJPpG9BbH9d/plKJm5ID3p2ojAGo5qvVuIJMNJA4elcfHDwzCWVmn
++MtR/WwtxYVVmy1BAnmk6HPSYc3CStvv1800vqN3fyJWtZ1P+8WBVZWZzIQdjdiaU
++JSRevPnjQGc+SAZQQIk1yVclbz5790yuXsdIxf8CgYEApqlABC5lsvfga4Vt1UMn
++j57FAkHe4KmPRCcZ83A88ZNGd/QWhkD9kR7wOsIz7wVqWiDkxavoZnjLIi4jP9HA
++jwEZ3zER8wl70bRy0IEOtZzj8A6fSzAu6Q+Au4RokU6yse3lZ+EcepjQvhBvnXLu
++ZxxAojj6AnsHzVf9WYJvlI0CgYEAoATIw/TEgRV/KNHs/BOiEWqP0Co5dVix2Nnk
++3EVAO6VIrbbE3OuAm2ZWeaBWSujXLHSmVfpoHubCP6prZVI1W9aTkAxmh+xsDV3P
++o3h+DiBTP1seuGx7tr7spQqFXeR3OH9gXktYCO/W0d3aQ7pjAjpehWv0zJ+ty2MI
++fQ/lkXUCgYEAgbP+P5UmY7Fqm/mi6TprEJ/eYktji4Ne11GDKGFQCfjF5RdKhdw1
++5+elGhZes+cpzu5Ak6zBDu4bviT+tRTWJu5lVLEzlHHv4nAU7Ks5Aj67ApH21AnP
++RtlATdhWOt5Dkdq1WSpDfz5bvWgvyBx9D66dSmQdbKKe2dH327eQll4=
+ -----END RSA PRIVATE KEY-----
+diff --git a/test/certs/embeddedSCTs1.pem b/test/certs/embeddedSCTs1.pem
+index d1e85120a043..d2a111fb8235 100644
+--- a/test/certs/embeddedSCTs1.pem
++++ b/test/certs/embeddedSCTs1.pem
+@@ -1,20 +1,21 @@
+ -----BEGIN CERTIFICATE-----
+-MIIDWTCCAsKgAwIBAgIBBzANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
++MIIDeDCCAuGgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBVMQswCQYDVQQGEwJHQjEk
+ MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+-YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+-MDAwMDBaMFIxCzAJBgNVBAYTAkdCMSEwHwYDVQQKExhDZXJ0aWZpY2F0ZSBUcmFu
+-c3BhcmVuY3kxDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGfMA0G
+-CSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+75jnwmh3rjhfdTJaDB0ym+3xj6r015a/
+-BH634c4VyVui+A7kWL19uG+KSyUhkaeb1wDDjpwDibRc1NyaEgqyHgy0HNDnKAWk
+-EM2cW9tdSSdyba8XEPYBhzd+olsaHjnu0LiBGdwVTcaPfajjDK8VijPmyVCfSgWw
+-FAn/Xdh+tQIDAQABo4IBOjCCATYwHQYDVR0OBBYEFCAxVBryXAX/2GWLaEN5T16Q
+-Nve0MH0GA1UdIwR2MHSAFF+diA3Ic+ZU1PgN2OawwSS0R8NVoVmkVzBVMQswCQYD
+-VQQGEwJHQjEkMCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4w
+-DAYDVQQIEwVXYWxlczEQMA4GA1UEBxMHRXJ3IFdlboIBADAJBgNVHRMEAjAAMIGK
+-BgorBgEEAdZ5AgQCBHwEegB4AHYA3xwuwRUAlFJHqWFoMl3cXHlZ6PfG04j8AC4L
+-vT9012QAAAE92yffkwAABAMARzBFAiBIL2dRrzXbplQ2vh/WZA89v5pBQpSVkkUw
+-KI+j5eI+BgIhAOTtwNs6xXKx4vXoq2poBlOYfc9BAn3+/6EFUZ2J7b8IMA0GCSqG
+-SIb3DQEBBQUAA4GBAIoMS+8JnUeSea+goo5on5HhxEIb4tJpoupspOghXd7dyhUE
+-oR58h8S3foDw6XkDUmjyfKIOFmgErlVvMWmB+Wo5Srer/T4lWsAERRP+dlcMZ5Wr
+-5HAxM9MD+J86+mu8/FFzGd/ZW5NCQSEfY0A1w9B4MHpoxgdaLiDInza4kQyg
++YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAgFw0yMDAxMjUxMTUwMTNaGA8yMTIwMDEy
++NjExNTAxM1owGTEXMBUGA1UEAwwOc2VydmVyLmV4YW1wbGUwggEiMA0GCSqGSIb3
++DQEBAQUAA4IBDwAwggEKAoIBAQC4iOkDj+IKkMDaaPLAjnMbogFfps1xFBgOwHsK
++/RWic1e0kHBfEwQ0/iNWm8SZaknmIwGScYdX5dYGSeBhqlzMixjgsafpoxTrJIAE
++FVCk05BJF9PjzEYY9H2bM4Eb/KmWakU5WrWP5vrmWyS8BcphosWkWfehj+kFJ1wI
++0E/wvKlVcAlvcioRewEv8SuAcb1uAhE/xXEEBqvILPvuQvMBeR8cvYt9IYh8043I
++QoHfEj3hLgt6i45KhYvVWQR8mzzu8bgbnGhfDco4fKK55BRSUye7yn4HHTE9Uo8S
++wuN7dH2TSsZrlxrt1cCf1TKkoqnbnHg1emeMZfm3FURh82+pAgMBAAGjggEMMIIB
++CDAdBgNVHQ4EFgQUtMa8XD5ylrF9AqCdnPEhXa63H2owHwYDVR0jBBgwFoAUX52I
++Dchz5lTU+A3Y5rDBJLRHw1UwCQYDVR0TBAIwADATBgNVHSUEDDAKBggrBgEFBQcD
++ATCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN8cLsEVAJRSR6lhaDJd3Fx5Wej3xtOI
++/AAuC70/dNdkAAABb15m6AAAAAQDAEcwRQIgfDPo8RArm/vcSEZ608Q1u+XQ55QB
++u67SZEuZxLpbUM0CIQDRsgcTud4PDy8Cgg+lHeAS7UxgSKBbWAznYOuorwNewzAZ
++BgNVHREEEjAQgg5zZXJ2ZXIuZXhhbXBsZTANBgkqhkiG9w0BAQsFAAOBgQCWFKKR
++RNkDRzB25NK07OLkbzebhnpKtbP4i3blRx1HAvTSamf/3uuHI7kfiPJorJymJpT1
++IuJvSVKyMu1qONWBimiBfiyGL7+le1izHEJIP5lVTbddfzSIBIvrlHHcWIOL3H+W
++YT6yTEIzJuO07Xp61qnB1CE2TrinUWlyC46Zkw==
+ -----END CERTIFICATE-----
+diff --git a/test/certs/embeddedSCTs1.sct b/test/certs/embeddedSCTs1.sct
+index 59362dcee1f4..35c9eb9e3bed 100644
+--- a/test/certs/embeddedSCTs1.sct
++++ b/test/certs/embeddedSCTs1.sct
+@@ -2,11 +2,11 @@ Signed Certificate Timestamp:
+     Version   : v1 (0x0)
+     Log ID    : DF:1C:2E:C1:15:00:94:52:47:A9:61:68:32:5D:DC:5C:
+                 79:59:E8:F7:C6:D3:88:FC:00:2E:0B:BD:3F:74:D7:64
+-    Timestamp : Apr  5 17:04:16.275 2013 GMT
++    Timestamp : Jan  1 00:00:00.000 2020 GMT
+     Extensions: none
+     Signature : ecdsa-with-SHA256
+-                30:45:02:20:48:2F:67:51:AF:35:DB:A6:54:36:BE:1F:
+-                D6:64:0F:3D:BF:9A:41:42:94:95:92:45:30:28:8F:A3:
+-                E5:E2:3E:06:02:21:00:E4:ED:C0:DB:3A:C5:72:B1:E2:
+-                F5:E8:AB:6A:68:06:53:98:7D:CF:41:02:7D:FE:FF:A1:
+-                05:51:9D:89:ED:BF:08
+\ No newline at end of file
++                30:45:02:20:7C:33:E8:F1:10:2B:9B:FB:DC:48:46:7A:
++                D3:C4:35:BB:E5:D0:E7:94:01:BB:AE:D2:64:4B:99:C4:
++                BA:5B:50:CD:02:21:00:D1:B2:07:13:B9:DE:0F:0F:2F:
++                02:82:0F:A5:1D:E0:12:ED:4C:60:48:A0:5B:58:0C:E7:
++                60:EB:A8:AF:03:5E:C3
+\ No newline at end of file
+diff --git a/test/certs/embeddedSCTs1_issuer-key.pem b/test/certs/embeddedSCTs1_issuer-key.pem
+new file mode 100644
+index 000000000000..9326e38b1eb7
+--- /dev/null
++++ b/test/certs/embeddedSCTs1_issuer-key.pem
+@@ -0,0 +1,15 @@
++-----BEGIN RSA PRIVATE KEY-----
++MIICXAIBAAKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7jHbrkVfT0PtLO1FuzsvR
++yY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjPKDHM5nugSlojgZ88ujfm
++JNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnLsvfP34b7arnRsQIDAQAB
++AoGAJLR6xEJp+5IXRFlLn7WTkFvO0ddtxJ7bXhiIkTctyruyfqp7LF9Jv1G2m3PK
++QPUtBc73w/GYkfnwIwdfJbOmPHL7XyEGHZYmEXgIgEtw6LXvAv0G5JpUnNwsSBfL
++GfSQqI5Z5ytyzlJXkMcTGA2kTgNAYc73h4EnU+pwUnDPdAECQQD2aj+4LtYk1XPq
++r3gjgI6MoGvgYJfPmAtZhxxVbhXQKciFUCAcBiwlQdHIdLWE9j65ctmZRWidKifr
++4O4nz+TBAkEA3djNW/rTQq5fKZy+mCF1WYnIU/3yhJaptzRqLm7AHqe7+hdrGXJw
+++mCtU8T3L/Ms8bH1yFBZhmkp1PbR8gl48QJAQo70YyWThiN5yfxXcQ96cZWrTdIJ
++b3NcLXSHPLQdhDqlBQ1dfvRT3ERpC8IqfZ2d162kBPhwh3MpkVcSPQK0gQJAC/dY
++xGBYKt2a9nSk9zG+0bCT5Kvq++ngh6hFHfINXNnxUsEWns3EeEzkrIMQTj7QqszN
++lBt5aL2dawZRNrv6EQJBAOo4STF9KEwQG0HLC/ryh1FeB0OBA5yIepXze+eJVKei
++T0cCECOQJKfWHEzYJYDJhyEFF/sYp9TXwKSDjOifrsU=
++-----END RSA PRIVATE KEY-----
+diff --git a/test/certs/embeddedSCTs1_issuer.pem b/test/certs/embeddedSCTs1_issuer.pem
+index 1fa449d5a098..6aa9455f09ed 100644
+--- a/test/certs/embeddedSCTs1_issuer.pem
++++ b/test/certs/embeddedSCTs1_issuer.pem
+@@ -1,18 +1,18 @@
+ -----BEGIN CERTIFICATE-----
+-MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
++MIIC0jCCAjugAwIBAgIBADANBgkqhkiG9w0BAQsFADBVMQswCQYDVQQGEwJHQjEk
+ MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+-YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+-MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+-c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+-MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+-jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+-KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+-svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+-tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+-A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+-MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+-/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+-OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+-f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+-OwqULg==
++YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAgFw0yMjA2MDExMDM4MDJaGA8yMTIyMDUw
++ODEwMzgwMlowVTELMAkGA1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRy
++YW5zcGFyZW5jeSBDQTEOMAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW4w
++gZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBANWKaFNiEKJxGZNud4MhGBwqQBPG
++0HuMduuRV9PQ+0s7UW7Oy9HJjZHFL3Q/q2NdVQmc0Tq68xrlQUQkUadMeBbyJDz4
++SM8oMczme6BKWiOBnzy6N+Yk2cO9spm4Od3+JjHSyzqE/HuytcUvz8FP/0BvXNRG
++acuy98/fhvtqudGxAgMBAAGjga8wgawwHQYDVR0OBBYEFF+diA3Ic+ZU1PgN2Oaw
++wSS0R8NVMH0GA1UdIwR2MHSAFF+diA3Ic+ZU1PgN2OawwSS0R8NVoVmkVzBVMQsw
++CQYDVQQGEwJHQjEkMCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENB
++MQ4wDAYDVQQIEwVXYWxlczEQMA4GA1UEBxMHRXJ3IFdlboIBADAMBgNVHRMEBTAD
++AQH/MA0GCSqGSIb3DQEBCwUAA4GBAD0aYh9OkFYfXV7kBfhrtD0PJG2U47OV/1qq
+++uFpqB0S1WO06eJT0pzYf1ebUcxjBkajbJZm/FHT85VthZ1lFHsky87aFD8XlJCo
++2IOhKOkvvWKPUdFLoO/ZVXqEVKkcsS1eXK1glFvb07eJZya3JVG0KdMhV2YoDg6c
++Doud4XrO
+ -----END CERTIFICATE-----
+
+From 03e1f16212530ade803482db1055c4c8921d762e Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Wed, 1 Jun 2022 13:06:46 +0200
+Subject: [PATCH 2/2] ct_test.c: Update the epoch time
+
+---
+ test/ct_test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/ct_test.c b/test/ct_test.c
+index 78d11ca98cf7..535897d09a77 100644
+--- a/test/ct_test.c
++++ b/test/ct_test.c
+@@ -63,7 +63,7 @@ static CT_TEST_FIXTURE *set_up(const char *const test_case_name)
+     if (!TEST_ptr(fixture = OPENSSL_zalloc(sizeof(*fixture))))
+         goto end;
+     fixture->test_case_name = test_case_name;
+-    fixture->epoch_time_in_ms = 1473269626000ULL; /* Sep 7 17:33:46 2016 GMT */
++    fixture->epoch_time_in_ms = 1580335307000ULL; /* Wed 29 Jan 2020 10:01:47 PM UTC */
+     if (!TEST_ptr(fixture->ctlog_store = CTLOG_STORE_new())
+             || !TEST_int_eq(
+                     CTLOG_STORE_load_default_file(fixture->ctlog_store), 1))

--- a/recipes-debian/openssl/openssl_debian.bbappend
+++ b/recipes-debian/openssl/openssl_debian.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://pr-18446-Update-expired-SCT-certificates.patch"


### PR DESCRIPTION
# Purpose of pull request

The openssl's ptest fails since 2022-06-01 00:00:00 GMT because some
certification files have been expired since that day.
Upstream already fixed this issue[1], but it hasn't been released yet.

So, apply patch from upstream to fix ptest failure until upstream and
debian releases new package.

[1]:https://github.com/openssl/openssl/pull/18446

# Test
## How to test

1. Build openssl 
2. Execute openssl ptest

## Test result

Building openssl package without any warnings.

```
masami@ubuntu1804:~/emlinux/qemuarm64-emlinux$ bitbake -f openssl
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2356 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:50914537ad7c4d1a7d75cf79a93adc239c5e3d05"
meta-debian-extended = "tmp-fix-openssl-ptest-error:ab9079114deaf5f669cf6f8deeb822eaa19bffb8"
meta-emlinux         = "warrior:5a78ba5b11c88e0ca1b0ebee2a37ae3fe0423deb"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-emlinux/../repos/meta-debian/recipes-debian/openssl/openssl_debian.bb, do_build                                                                    | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-emlinux/../repos/meta-debian/recipes-debian/openssl/openssl_debian.bb.do_build is tainted from a forced run                                                                            | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 6 Found 0 Missed 6 Current 420 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1969 tasks of which 1950 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

ptest succeeded.

```
root@qemuarm64:~# /usr/bin/ptest-runner openssl -t 3600
START: /usr/bin/ptest-runner
2022-06-02T06:01                                                                                                                                                                                                                              
BEGIN: /usr/lib/openssl/ptest
PASS: test/recipes/01-test_abort.t
PASS: test/recipes/01-test_sanity.t
SKIP: test/recipes/01-test_symbol_presence.t (The case needs debug symbols then we just disable it)
PASS: test/recipes/01-test_test.t
PASS: test/recipes/02-test_errstr.t
PASS: test/recipes/02-test_internal_ctype.t
PASS: test/recipes/02-test_lhash.t
PASS: test/recipes/02-test_ordinals.t
PASS: test/recipes/02-test_stack.t
PASS: test/recipes/03-test_exdata.t
PASS: test/recipes/03-test_internal_asn1.t
PASS: test/recipes/03-test_internal_chacha.t
PASS: test/recipes/03-test_internal_curve448.t
PASS: test/recipes/03-test_internal_ec.t
PASS: test/recipes/03-test_internal_mdc2.t
PASS: test/recipes/03-test_internal_modes.t
PASS: test/recipes/03-test_internal_poly1305.t
PASS: test/recipes/03-test_internal_siphash.t
PASS: test/recipes/03-test_internal_sm2.t
PASS: test/recipes/03-test_internal_sm4.t
PASS: test/recipes/03-test_internal_ssl_cert_table.t
PASS: test/recipes/03-test_internal_x509.t
PASS: test/recipes/03-test_ui.t
PASS: test/recipes/04-test_asn1_decode.t
PASS: test/recipes/04-test_asn1_encode.t
PASS: test/recipes/04-test_asn1_string_table.t
PASS: test/recipes/04-test_bio_callback.t
PASS: test/recipes/04-test_bioprint.t
PASS: test/recipes/04-test_err.t
PASS: test/recipes/04-test_pem.t                       
PASS: test/recipes/05-test_bf.t
PASS: test/recipes/05-test_cast.t
PASS: test/recipes/05-test_cmac.t
PASS: test/recipes/05-test_des.t
PASS: test/recipes/05-test_hmac.t
PASS: test/recipes/05-test_idea.t
SKIP: test/recipes/05-test_md2.t (md2 is not supported by this OpenSSL build)
PASS: test/recipes/05-test_mdc2.t
PASS: test/recipes/05-test_rand.t
PASS: test/recipes/05-test_rc2.t
PASS: test/recipes/05-test_rc4.t
SKIP: test/recipes/05-test_rc5.t (rc5 is not supported by this OpenSSL build)
PASS: test/recipes/06-test-rdrand.t
PASS: test/recipes/10-test_bn.t
PASS: test/recipes/10-test_exp.t
PASS: test/recipes/15-test_dh.t
PASS: test/recipes/15-test_dsa.t
PASS: test/recipes/15-test_ec.t
PASS: test/recipes/15-test_ecdsa.t
PASS: test/recipes/15-test_ecparam.t
PASS: test/recipes/15-test_genec.t
PASS: test/recipes/15-test_genrsa.t
PASS: test/recipes/15-test_mp_rsa.t
PASS: test/recipes/15-test_out_option.t
PASS: test/recipes/15-test_rsa.t
PASS: test/recipes/15-test_rsapss.t
PASS: test/recipes/20-test_dgst.t
PASS: test/recipes/20-test_enc.t
PASS: test/recipes/20-test_enc_more.t
PASS: test/recipes/20-test_passwd.t
PASS: test/recipes/25-test_crl.t
PASS: test/recipes/25-test_d2i.t
PASS: test/recipes/25-test_pkcs7.t
PASS: test/recipes/25-test_req.t
PASS: test/recipes/25-test_sid.t
PASS: test/recipes/25-test_verify.t
PASS: test/recipes/25-test_x509.t
PASS: test/recipes/30-test_afalg.t
PASS: test/recipes/30-test_engine.t
PASS: test/recipes/30-test_evp.t
PASS: test/recipes/30-test_evp_extra.t
PASS: test/recipes/30-test_pbelu.t
PASS: test/recipes/30-test_pkey_meth.t
PASS: test/recipes/30-test_pkey_meth_kdf.t
PASS: test/recipes/40-test_rehash.t
PASS: test/recipes/60-test_x509_check_cert_pkey.t
PASS: test/recipes/60-test_x509_dup_cert.t
PASS: test/recipes/60-test_x509_store.t
PASS: test/recipes/60-test_x509_time.t
PASS: test/recipes/70-test_asyncio.t
PASS: test/recipes/70-test_bad_dtls.t
PASS: test/recipes/70-test_clienthello.t
PASS: test/recipes/70-test_comp.t
PASS: test/recipes/70-test_key_share.t
PASS: test/recipes/70-test_packet.t
PASS: test/recipes/70-test_recordlen.t
PASS: test/recipes/70-test_renegotiation.t
PASS: test/recipes/70-test_servername.t
PASS: test/recipes/70-test_sslcbcpadding.t
PASS: test/recipes/70-test_sslcertstatus.t
PASS: test/recipes/70-test_sslextension.t
PASS: test/recipes/70-test_sslmessages.t
PASS: test/recipes/70-test_sslrecords.t
PASS: test/recipes/70-test_sslsessiontick.t
PASS: test/recipes/70-test_sslsigalgs.t
PASS: test/recipes/70-test_sslsignature.t
PASS: test/recipes/70-test_sslskewith0p.t
PASS: test/recipes/70-test_sslversions.t
PASS: test/recipes/70-test_sslvertol.t
PASS: test/recipes/70-test_tls13alerts.t
PASS: test/recipes/70-test_tls13cookie.t
PASS: test/recipes/70-test_tls13downgrade.t
PASS: test/recipes/70-test_tls13hrr.t
PASS: test/recipes/70-test_tls13kexmodes.t
PASS: test/recipes/70-test_tls13messages.t
PASS: test/recipes/70-test_tls13psk.t
PASS: test/recipes/70-test_tlsextms.t
PASS: test/recipes/70-test_verify_extra.t
PASS: test/recipes/70-test_wpacket.t
PASS: test/recipes/80-test_ca.t
PASS: test/recipes/80-test_cipherbytes.t
PASS: test/recipes/80-test_cipherlist.t
PASS: test/recipes/80-test_ciphername.t
PASS: test/recipes/80-test_cms.t
PASS: test/recipes/80-test_cmsapi.t
PASS: test/recipes/80-test_ct.t
PASS: test/recipes/80-test_dane.t
PASS: test/recipes/80-test_dtls.t
PASS: test/recipes/80-test_dtls_mtu.t
PASS: test/recipes/80-test_dtlsv1listen.t
PASS: test/recipes/80-test_ocsp.t
PASS: test/recipes/80-test_pkcs12.t
PASS: test/recipes/80-test_ssl_new.t
PASS: test/recipes/80-test_ssl_old.t
PASS: test/recipes/80-test_ssl_test_ctx.t
PASS: test/recipes/80-test_sslcorrupt.t
PASS: test/recipes/80-test_tsa.t
PASS: test/recipes/80-test_x509aux.t
PASS: test/recipes/90-test_asn1_time.t
PASS: test/recipes/90-test_async.t
PASS: test/recipes/90-test_bio_enc.t
PASS: test/recipes/90-test_bio_memleak.t
PASS: test/recipes/90-test_constant_time.t
PASS: test/recipes/90-test_fatalerr.t
PASS: test/recipes/90-test_gmdiff.t
SKIP: test/recipes/90-test_gost.t (No test GOST engine found)
PASS: test/recipes/90-test_ige.t
PASS: test/recipes/90-test_includes.t
PASS: test/recipes/90-test_memleak.t
SKIP: test/recipes/90-test_overhead.t (Only supported in no-shared builds)
PASS: test/recipes/90-test_secmem.t
PASS: test/recipes/90-test_shlibload.t
PASS: test/recipes/90-test_srp.t
PASS: test/recipes/90-test_sslapi.t
PASS: test/recipes/90-test_sslbuffers.t
PASS: test/recipes/90-test_store.t
PASS: test/recipes/90-test_sysdefault.t
PASS: test/recipes/90-test_threads.t
PASS: test/recipes/90-test_time_offset.t
PASS: test/recipes/90-test_tls13ccs.t
PASS: test/recipes/90-test_tls13encryption.t
PASS: test/recipes/90-test_tls13secrets.t
PASS: test/recipes/90-test_v3name.t
SKIP: test/recipes/95-test_external_boringssl.t (No external tests in this configuration)
SKIP: test/recipes/95-test_external_krb5.t (No external tests in this configuration)
SKIP: test/recipes/95-test_external_pyca.t (No external tests in this configuration)
PASS: test/recipes/99-test_ecstress.t
PASS: test/recipes/99-test_fuzz.t
All tests successful.
Files=158, Tests=2636, 2928 wallclock secs (30.58 usr  2.27 sys + 1034.82 cusr 227.97 csys = 1295.64 CPU)
Result: PASS
DURATION: 2931
END: /usr/lib/openssl/ptest
2022-06-02T06:50
STOP: /usr/bin/ptest-runner
```



