### PR TITLE
libpcap: Fix patch fuzz error in libpcap-pkgconfig-support.patch

### DIFF
--- a/recipes-debian/libpcap/libpcap/libpcap-pkgconfig-support.patch
+++ b/recipes-debian/libpcap/libpcap/libpcap-pkgconfig-support.patch
@@ -1,4 +1,4 @@
-From fd189e80562106c9438c66bb55324a7fcf146a2d Mon Sep 17 00:00:00 2001
+From 358b72964006d1584dba560a65161185f083b958 Mon Sep 17 00:00:00 2001
 From: Fabio Berton <fabio.berton@ossystems.com.br>
 Date: Thu, 3 Nov 2016 17:56:29 -0200
 Subject: [PATCH] libpcap: pkgconfig support
@@ -10,6 +10,8 @@ Upstream-Status: Inappropriate [embedded specific]
 Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
 Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
 
+[Fix "libpcap-1.8.1-r0 do_patch: Fuzz detected" error]
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
 ---
  Makefile.in   |  5 +++++
  configure.ac  |  1 +
@@ -18,10 +20,10 @@ Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
  create mode 100644 libpcap.pc.in
 
 diff --git a/Makefile.in b/Makefile.in
-index d8562f1..909f6bc 100644
+index a244601..903cbc8 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -68,6 +68,10 @@ V_RPATH_OPT = @V_RPATH_OPT@
+@@ -69,6 +69,10 @@ V_RPATH_OPT = @V_RPATH_OPT@
  DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
  PROG=libpcap
  
@@ -31,7 +33,7 @@ index d8562f1..909f6bc 100644
 +
  # Standard CFLAGS
  FULL_CFLAGS = $(CCOPT) $(INCLS) $(DEFS) $(CFLAGS) $(CPPFLAGS)
- CFLAGS_SHARED = -shared -Wl,-soname,$(SOLIBRARY).$(MAJ) -Wl,--version-script=libpcap-symbols.lds
+ CFLAGS_SHARED = -shared -Wl,-soname,$(SOLIBRARY).$(MAJ) -Wl,--version-script=$(srcdir)/libpcap-symbols.lds
 @@ -300,6 +304,7 @@ EXTRA_DIST = \
  	lbl/os-solaris2.h \
  	lbl/os-sunos4.h \
@@ -68,3 +70,6 @@ index 0000000..4f78ad8
 +Version: @VERSION@
 +Libs: -L${libdir} -lpcap
 +Cflags: -I${includedir}
+-- 
+2.17.1
+


### PR DESCRIPTION
# Purpose of pull request

```
This commit fixes following patch fuzz detected error.

ERROR: libpcap-1.8.1-r0 do_patch: Fuzz detected:

Applying patch libpcap-pkgconfig-support.patch
patching file Makefile.in
Hunk #1 succeeded at 69 with fuzz 1 (offset 1 line).
patching file configure.ac
patching file libpcap.pc.in

The context lines in the patches can be updated with devtool:

    devtool modify libpcap
    devtool finish --force-patch-refresh libpcap <layer_path>

Don't forget to review changes done by devtool!

ERROR: libpcap-1.8.1-r0 do_patch: QA Issue: Patch log indicates that patches do not apply cleanly. [patch-fuzz]
```

The libpcap-pkgconfig-support.patch patch applied after do_debian_patch task,
so this changes cleanly apply to libpcap source which based on debian source.

# Test
## How to test

Build libpcap

```
# bitbake libpcap
```

## Test result

```
$ bitbake -f libpcap
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2354 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:50914537ad7c4d1a7d75cf79a93adc239c5e3d05"
meta-debian-extended = "libpcap-fix-libpcap-patch-fuzz:65de425235d3bde451c15f8199ed3443e34308f4"
meta-emlinux         = "warrior:415190c9f031a8d46ed88cecb950998606d507e7"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/truly-latest/build-emlinux/../repos/meta-debian/recipes-debian/libpcap/libpcap_debian.bb, do_build                   | ETA:  0:00:00
WARNING: /home/masami/emlinux/truly-latest/build-emlinux/../repos/meta-debian/recipes-debian/libpcap/libpcap_debian.bb.do_build is tainted from a forced run                           | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 6 Found 0 Missed 6 Current 552 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2489 tasks of which 2473 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```



