### PR TITLE
libpwquality: Add libpwquality license file

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,3 +13,5 @@ LAYERDEPENDS_debian-extended = "core debian"
 LAYERSERIES_COMPAT_debian-extended = "warrior"
 
 LAYERDIR_DEBIAN_debian-extended = '${@os.path.normpath("${LAYERDIR}")}'
+
+LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/licneses/libpwquality
+++ b/licneses/libpwquality
@@ -1,0 +1,16 @@
+Redistribution and use in source and binary forms of libpwquality, with
+ or without modification, are permitted provided that the following
+ conditions are met:
+ .
+ 1. Redistributions of source code must retain any existing copyright
+    notice, and this entire permission notice in its entirety,
+    including the disclaimer of warranties.
+ .
+ 2. Redistributions in binary form must reproduce all prior and current
+    copyright notices, this list of conditions, and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+ .
+ 3. The name of any author may not be used to endorse or promote
+    products derived from this software without their specific prior
+    written permission.


### PR DESCRIPTION
# Purpose of pull request

This change fixes following warning.

```
WARNING: libpwquality-1.4.0-r0 do_populate_lic: libpwquality: No generic license file exists for: libpwquality in any provider
```

According to the debian copyright file[1], the libpwquality has dual
license which the one is libpwquality and the other is GPL-2+.

The libpwquality license is not common license so that it doesn't exist
in meta/files/common-licenses in poky.

Therefore, get the license from debian's copyright file[1], then added
it to custom-licenses directory.

1. https://metadata.ftp-master.debian.org/changelogs//main/libp/libpwquality/libpwquality_1.4.0-3_copyright


# Test
## How to test

build libpwquality package.

```
$ bitbake libpwquality
```

There is no QA warnings.

## Test result

```
build@914ca7500705:~/emlinux/emlinux-security/build$ bitbake libpwquality
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2357 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:50914537ad7c4d1a7d75cf79a93adc239c5e3d05"
meta-debian-extended = "add-pwquality-license:7a4e494fb233103911c319a5a769dbe8480e086d"
meta-emlinux         = "HEAD:415190c9f031a8d46ed88cecb950998606d507e7"
meta-cip-security    = "HEAD:48cda39798b064ce09339fb3a70e93cda3f70f98"
meta-emlinux-security = "HEAD:ca7ed57c2bfeb40d13385459a3f1f52945413af1"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 6 Found 0 Missed 6 Current 457 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2109 tasks of which 2093 didn't need to be rerun and all succeeded.
```



