### PR TITLE
Fix python3-pycairo and python3-pygobject pkg-config problem

### DIFF
--- a/recipes-debian/python/python3-pycairo_debian.bb
+++ b/recipes-debian/python/python3-pycairo_debian.bb
@@ -29,6 +29,12 @@ BBCLASSEXTEND = "native"
 do_install_append() {
     install -d ${D}${includedir}/pycairo/
     install -m 0644 ${D}${datadir}/include/pycairo/py3cairo.h ${D}${includedir}/pycairo/
+
+    # install .pc file to /usr/lib/pkgconfig instead of /usr/share/lib/pkgconfig
+    # When building pygobject, configure process will be able to find /usr/lib/pkgconfig/py3cairo.pc
+    install -d ${D}${libdir}/pkgconfig
+    cp --no-preserve=ownership ${D}${datadir}/lib/pkgconfig/py3cairo.pc ${D}${libdir}/pkgconfig/py3cairo.pc
+    rm -rf ${D}${datadir}/lib/
 }
 FILES_${PN} += "${datadir}/include/pycairo/py3cairo.h"
-FILES_${PN} += "${datadir}/lib/pkgconfig/py3cairo.pc"
+FILES_${PN} += "${libdir}/pkgconfig/py3cairo.pc"

--- a/recipes-debian/python/python3-pygobject_debian.bb
+++ b/recipes-debian/python/python3-pygobject_debian.bb
@@ -49,11 +49,4 @@ do_install_append_class-target() {
     mv ${D}/usr/usr/lib/* ${D}/usr/lib/.
     rm -fr ${D}/usr/usr
   fi
-
-  # Workaround for the conflict with pycairo
-  rm -fr \
-    ${D}/usr/include/pycairo \
-    ${D}/usr/lib/pkgconfig/py3cairo.pc \
-    ${D}/usr/lib/python3.7/site-packages/cairo \
-    ${D}/usr/lib/python3.7/site-packages/pycairo-1.18.2.egg-info
 }


### PR DESCRIPTION
# Purpose of pull request

This PR fixes python3-pycairo and python3-pygobject pkg-config problem.

The main problem is python3-pycairo recipe installs py3cairo.pc into /usr/share/lib/pkgconfig which is not usual path in debian system (https://packages.debian.org/buster/all/python3-cairo-dev/filelist) .  

Therefore, python3-pygobject's configure process couldn't find py3cairo as below.

```
 281 Determining dependency 'py3cairo' with pkg-config executable '/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot-native/usr/bin     /pkg-config'
 282 Called `/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot-native/usr/bin/pkg-config --modversion py3cairo` -> 1
 283 
 284 Dependency py3cairo not found: CMake binary missing from cross file
 285 Cross dependency py3cairo found: NO (tried pkgconfig)
 286 Looking for a fallback subproject for the dependency py3cairo
 287 
 288 
 289 Executing subproject pycairo
 290 
```

So, install py3cairo.pc into /usr/lib/pkgconfig instead of /usr/share/lib/pkgconfig.

Another change is remove workaround in python3-pygobject recipe.  It build pycairo if configure process doesn't find py3cairo.pc. In this case,  it install pycairo related files. However, if python3-pygobject doesn't build py3cairo, this workaround doesn't need. 

So, python3-pycairo recipe installs pc file into /usr/lib/pkgconfig now, we don't need this workaround.


# Test
## How to test

1. Build python3-pygobject
2. Add "IMAGE_INSTALL_append = " python3-pygobject"' to conf/local.conf then build SDK

## Test result

Configure process found py3cairo.

```
288 Called `/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot-native/usr/bin/pkg-config py3cairo --libs` -> 0
289 -lcairo
290 Cross dependency py3cairo found: YES 1.16.2
291 Running compile:
292 Working directory:  /home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/build/meson-private/tmp/tmpuyarkmrz
293 Command line:  aarch64-emlinux-linux-gcc -march=armv8-a+crc --sysroot=/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot /home/b    uild/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/build/meson-private/tmp/tmpuyarkmrz/testfile.c -pipe -D_FILE_OFFSET_BITS=64 -c -o /home/build/emlin    ux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/build/meson-private/tmp/tmpuyarkmrz/output.obj -O2 -g -feliminate-unused-debug-types -fmacro-prefix-map=/home    /build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0=/usr/src/debug/python3-pygobject/3.30.4-r0 -fdebug-prefix-map=/home/build/emlinux/latest-dev/buil    d/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0=/usr/src/debug/python3-pygobject/3.30.4-r0 -fdebug-prefix-map=/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlin    ux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot= -fdebug-prefix-map=/home/build/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/python3-pygobject/3.30.4-r0/recipe-sysroot-nativ    e= -O0 -Wall
```

python3-pygobject build succeeded.

```
$ bitbake python3-pygobject
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2360 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.6"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:0907a7105f0ddb552553e2306946793c3ee272de"
meta-debian-extended = "py3cairo-fix:978df86cedb5d8b91ca2432cc64aa9449d03e34e"
meta-emlinux         = "HEAD:145d64f945a45efa730404d532b629ef839abbbc"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 6 Found 0 Missed 6 Current 535 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2405 tasks of which 2388 didn't need to be rerun and all succeeded.
```

Building SDK succeeded

```
$ bitbake core-image-minimal-sdk -c populate_sdk                                                                                                                                                    
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:11
Parsing of 1343 .bb files complete (0 cached, 1343 parsed). 2360 targets, 80 skipped, 6 masked, 0 errors.
Removing 1 recipes from the aarch64 sysroot: 100% |####################################################################################################################################| Time: 0:00:00
Removing 1 recipes from the qemuarm64 sysroot: 100% |##################################################################################################################################| Time: 0:00:00
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.6"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:0907a7105f0ddb552553e2306946793c3ee272de"
meta-debian-extended = "py3cairo-fix:978df86cedb5d8b91ca2432cc64aa9449d03e34e"
meta-emlinux         = "HEAD:145d64f945a45efa730404d532b629ef839abbbc"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 490 Found 0 Missed 490 Current 437 (0% match, 47% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3744 tasks of which 2152 didn't need to be rerun and all succeeded.
```