### PR TITLE
libsndfile: Add CVE-2018-13419 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/libsndfile/libsndfile1_debian.bb
+++ b/recipes-debian/libsndfile/libsndfile1_debian.bb
@@ -41,3 +41,5 @@ do_configure_prepend_arm() {
 	export ac_cv_sys_file_offset_bits=64
 }
 
+# CVE-2018-13419: Upstream closed this bug because it is not reproducible and not test script was provided. https://github.com/libsndfile/libsndfile/issues/398
+CVE_CHECK_WHITELIST = "CVE-2018-13419"


### PR DESCRIPTION


# Purpose of pull request

Upstream closed this bug (https://github.com/libsndfile/libsndfile/issues/398) because it is not reproducible and not test script was provided.
So, it is okay to ignore this CVE.

# Test
## How to test

Run cve-check task

```
# bitbake libsndfile1 -c cve_check
```

## Test result

Without this patch CVE-2018-13419 should be shown.

```
NOTE: Executing RunQueue Tasks
WARNING: libsndfile1-1.0.28-r0 do_cve_check: Found unpatched CVE (CVE-2018-13419), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/libsndfile1/1.0.28-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```

With this patch CVE-2018-13419 shouldn't be shown.

```
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```



