### PR TITLE
pacemaker: Remove build host path

### DIFF
--- a/recipes-debian/pacemaker/pacemaker_debian.bb
+++ b/recipes-debian/pacemaker/pacemaker_debian.bb
@@ -1,6 +1,6 @@
 #base recipe: meta-cgl/meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb
-#base branch: dunfell
-#base commit: b8529657086ba4d308ee8cc99b720aaedaa3ae18
+#base branch: kirkstone
+#base commit: a11078b34f53842e5eeb9b112fdd4a4255b96296
 
 SUMMARY = "Scalable High-Availability cluster resource manager"
 DESCRIPTION = "Pacemaker is an advanced, scalable High-Availability \
@@ -54,6 +54,19 @@ CACHED_CONFIGUREVARS += " \
     ac_cv_path_BASH_PATH=/bin/bash \
 "
 
+do_configure_prepend() {
+    # remove buildpath
+    placeh="abs_top_builddir abs_top_srcdir"
+    for ph in $placeh
+    do
+        srcdirs=$(grep -Rn $ph ${S}/* | awk -F: '{print $1}' | uniq)
+        for srcdir in $srcdirs
+        do
+            sed -i "s/${ph}/${ph}_placeholder/g" $srcdir
+        done
+    done
+}
+
 do_install_append() {
     install -d ${D}${sysconfdir}/default
     install -d ${D}${sysconfdir}/default/volatiles
@@ -73,6 +86,19 @@ do_install_append() {
 
     rm -rf ${D}${localstatedir}/lib/heartbeat
     rm -rf ${D}${localstatedir}/run
+
+    # remove buildpath
+    tempdirs=$(grep -Rn ${RECIPE_SYSROOT_NATIVE} ${D}/* | awk -F: '{print $1}' | uniq)
+    for temdir in $tempdirs
+    do
+        sed -i "s:${RECIPE_SYSROOT_NATIVE}::g" $temdir
+    done
+
+    hostdir=$(grep -Rn ${HOSTTOOLS_DIR} ${D}/* | awk -F: '{print $1}' | uniq)
+    for tmpdir in $hostdir
+   do
+        sed -i "s:${HOSTTOOLS_DIR}::g" $tmpdir
+    done
 }
 
 PACKAGES_prepend = "${PN}-cli-utils ${PN}-libs ${PN}-cluster-libs ${PN}-remote "


### PR DESCRIPTION
# Purpose of pull request

Remove build host path
File installed by pacemaker-cli-utils contains path of build host.

This backports a11078b34f53842e5eeb9b112fdd4a4255b96296 
This backports 9c4639cd21f0ee11fdecb171c3173a0214a23612

```
emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/image$ rgrep -rn "build/tmp-glibc"
usr/sbin/crm_failcount:212:TEMP=$(/home/koji/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/recipe-sysroot-native/bin/getopt -o $SHORTOPTS --long $LONGOPTS -n crm_failcount -- "$@")
usr/sbin/crm_report:9:TEMP=`/home/koji/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/recipe-sysroot-native/bin/getopt                    \
usr/sbin/crm_master:48:TEMP=$(/home/koji/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/recipe-sysroot-native/bin/getopt -o ${SHORTOPTS}${SHORTOPTS_DEPRECATED} \
usr/sbin/crm_standby:54:TEMP=$(/home/koji/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/recipe-sysroot-native/bin/getopt -o ${SHORTOPTS}${SHORTOPTS_DEPRECATED} \
```

# Test
## How to test

Building pacemaker package
Make sure the build host path is not included.


Run following command from Host PC console
```
$ cd build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/image
$ rgrep -rn "build/tmp-glibc"
```
Run following command from console
```
# cat /usr/sbin/crm_failcount | grep getopt
# cat /usr/sbin/crm_report | grep getopt
# cat /usr/sbin/crm_master | grep getopt
# cat /usr/sbin/crm_standby | grep getopt
```

## Test result
```
koji@koji:~/emlinux$ cd build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/image
koji@koji:~/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/image$ rgrep -rn "build/tmp-glibc"
koji@koji:~/emlinux/build/tmp-glibc/work/aarch64-emlinux-linux/pacemaker/2.0.1-r0/image$
```
```
root@qemuarm64:~# cat /usr/sbin/crm_failcount | grep TEMP
TEMP=$(/bin/getopt -o $SHORTOPTS --long $LONGOPTS -n crm_failcount -- "$@")
eval set -- "$TEMP" # Quotes around $TEMP are essential
root@qemuarm64:~# cat /usr/sbin/crm_report | grep TEMP
TEMP=`/bin/getopt                       \
# The quotes around $TEMP are essential
eval set -- "$TEMP"
root@qemuarm64:~# cat /usr/sbin/crm_master | grep TEMP
TEMP=$(/bin/getopt -o ${SHORTOPTS}${SHORTOPTS_DEPRECATED} \
eval set -- "$TEMP" # Quotes around $TEMP are essential
root@qemuarm64:~# cat /usr/sbin/crm_standby | grep TEMP
TEMP=$(/bin/getopt -o ${SHORTOPTS}${SHORTOPTS_DEPRECATED} \
eval set -- "$TEMP" # Quotes around $TEMP are essential
```



