### PR TITLE
elfutils: Remove bbappend file

### DIFF
--- a/recipes-debian/elfutils/elfutils_debian.bbappend
+++ b/recipes-debian/elfutils/elfutils_debian.bbappend
@@ -1,1 +1,0 @@
-SRC_URI += "file://0007-Fix-control-path-where-we-have-str-as-uninitialized-.patch"


### PR DESCRIPTION
# Purpose of pull request

With elfutils_0.176-1.1+deb10u1 on meta-debian,
the '0007-Fix-control-path-where-we-have-str-as-uninitialized-.patch' patch file is no longer needed.
As a result, the bbappend file itself is no longer needed, so removed it.

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment


## How to test
1. Build qemuarm64 image
2. Run qemu image
3. Run test commands

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
IMAGE_INSTALL_append = " elfutils"
```
```
$ bitbake core-image-minimal
```

### Run qemu image
```
$ runqemu qemuarm64 nographic
```

### Run test commands
```
# ls -la /usr/bin/eu*
# eu-ar --version
# eu-elfcmp --version
# eu-elfcompress --version
# eu-elflint --version
# eu-findtextrel --version
# eu-make-debug-archive --version
# eu-ranlib --version
# eu-stack --version
# eu-strings --version
# eu-unstrip --version
```

## Test result
### build
Build succeeded.
```
$ bitbake elfutils
Checking Debian Release ...
Sources.xz is not changed.
Force regenerate source code information.
Parsing Debian Sources.xz ...
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:03:06
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2382 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:e14638eb3d032cc49400434fd17f66e5d1df1f6e"
meta-debian-extended = "remove-elfutils-bbappend:743c2b1e7d4a1a8b713d1be48f8b444812d537c8"
meta-emlinux         = "HEAD:4dd2259ccc4eaaa6dece7f164eb2827bd09eadc4"
meta-emlinux-private = "HEAD:8207525289999d2c41983eb8155127b62621cdb1"

Initialising tasks: 100% |#######################################################################################################################################################################################################################################| Time: 0:00:11
Sstate summary: Wanted 0 Found 0 Missed 0 Current 426 (0% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1969 tasks of which 1969 didn't need to be rerun and all succeeded.
```

### Package test
The elfutils command exists and is working.
```
root@qemuarm64:~# ls -la /usr/bin/eu*
-rwxr-xr-x    1 root     root         35424 Oct 16 08:44 /usr/bin/eu-ar
-rwxr-xr-x    1 root     root         31224 Oct 16 08:44 /usr/bin/eu-elfcmp
-rwxr-xr-x    1 root     root         27128 Oct 16 08:44 /usr/bin/eu-elfcompress
-rwxr-xr-x    1 root     root        109248 Oct 16 08:44 /usr/bin/eu-elflint
-rwxr-xr-x    1 root     root         14728 Oct 16 08:44 /usr/bin/eu-findtextrel
-rwxr-xr-x    1 root     root          2911 Oct 16 08:44 /usr/bin/eu-make-debug-archive
-rwxr-xr-x    1 root     root         18848 Oct 16 08:44 /usr/bin/eu-ranlib
-rwxr-xr-x    1 root     root         23048 Oct 16 08:44 /usr/bin/eu-stack
-rwxr-xr-x    1 root     root         18864 Oct 16 08:44 /usr/bin/eu-strings
-rwxr-xr-x    1 root     root         43672 Oct 16 08:44 /usr/bin/eu-unstrip
root@qemuarm64:~# eu-ar --version
eu-ar (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-elfcmp --version
eu-elfcmp (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-elfcompress --version
eu-elfcompress (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-elflint --version
eu-elflint (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-findtextrel --version
eu-findtextrel (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-make-debug-archive --version
eu-make-debug-archive (elfutils) 0.176
Copyright (C) 2007 Red Hat, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or
FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath.
root@qemuarm64:~# eu-ranlib --version
eu-ranlib (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-stack --version
eu-stack (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-strings --version
eu-strings (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
root@qemuarm64:~# eu-unstrip --version
eu-unstrip (elfutils) 0.176
Copyright (C) 2018 The elfutils developers <http://elfutils.org/>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```


