### PR TITLE
resource-agents: Remove ldirectord files from resource-agents package

### DIFF
--- a/recipes-debian/cluster-resource-agents/resource-agents_debian.bb
+++ b/recipes-debian/cluster-resource-agents/resource-agents_debian.bb
@@ -68,6 +68,13 @@ do_install_append() {
 
     rm ${D}${libdir}/ocf/resource.d/redhat
     ln -sf ../../../share/cluster ${D}${libdir}/ocf/resource.d/redhat
+    # remove ldirectord-related files
+    rm ${D}${sbindir}/ldirectord
+    rm ${D}${libdir}/ocf/resource.d/heartbeat/ldirectord
+    rm ${D}${sysconfdir}/init.d/ldirectord
+    rm ${D}${sysconfdir}/ha.d/resource.d/ldirectord
+    rm ${D}${sysconfdir}/logrotate.d/ldirectord
+    rm ${D}${mandir}/man8/ldirectord.8
 }
 
 # tickle_tcp is published under GPLv3, we just split it into ${PN}-extra,


### PR DESCRIPTION
# Purpose of pull request
This PR removes unnecessary files that are included as a part of resource-agents package.
The removed files are related to `ldirectord`, which is another package in Debian packages: https://packages.debian.org/buster/ldirectord

# Test
## How to test

1. Build image
2. Run the image and check the removed files does not exist.

Run the following commands to know the files does not exist.
```
root@qemuarm64:~# [ -f /path/to/file ] && echo "File exists" || echo "File does not exist"
```

## Test results
```
root@qemuarm64:~# [ -f /usr/sbin/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
root@qemuarm64:~# [ -f /usr/lib/ocf/resource.d/heartbeat/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
root@qemuarm64:~# [ -f /etc/init.d/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
root@qemuarm64:~# [ -f /etc/ha.d/resource.d/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
root@qemuarm64:~# [ -f /etc/logrotate.d/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
root@qemuarm64:~# [ -f /usr/share/man/man8/ldirectord ] && echo "File exists" || echo "File does not exist"
File does not exist
```




