### PR TITLE
apparmor: Add suport systemd environment

### DIFF
--- a/recipes-debian/AppArmor/apparmor_debian.bb
+++ b/recipes-debian/AppArmor/apparmor_debian.bb
@@ -188,6 +188,10 @@ do_install_ptest () {
     cp -rf ${B}/binutils ${t}
 }
 
+python rm_sysvinit_initddir () {
+    pass
+}
+
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME = "apparmor"
 INITSCRIPT_PARAMS = "start 16 2 3 4 5 . stop 35 0 1 6 ."


### PR DESCRIPTION

# Purpose of pull request

apparmor.service is a wrapper for /etc/init.d/apparmor. 
However, bitbake removes sysvinit-scripts at build time in a systemd environment. (On the other hand, in a sysvinit environment, bitbake removes the systemd.service file.) This caused a issue that apparmor could not be started when systemd is enabled.

To solve this issue, this patch will not make bitbake delete sysvinit-scripts in apparmor build.

Fix:
```
| Nov 16 04:25:25 qemuarm64 systemd[1]: Starting AppArmor initialization... 
| Nov 16 04:25:25 qemuarm64 systemd[171]: apparmor.service: Failed to execute command: No such file or directory 
| Nov 16 04:25:25 qemuarm64 systemd[171]: apparmor.service: Failed at step EXEC spawning /etc/init.d/apparmor: No such file or directory 
| Nov 16 04:25:25 qemuarm64 systemd[1]: apparmor.service: Main process exited, code=exited, status=203/EXEC 
| Nov 16 04:25:25 qemuarm64 systemd[1]: apparmor.service: Failed with result 'exit-code'. 
| Nov 16 04:25:25 qemuarm64 systemd[1]: Failed to start AppArmor initialization.
```

# Test
## How to test

1. Enable kernel-modules for apparmor

```
$: . setup-emlinux
$: cat << EOF >> ../repos/meta-emlinux/recipes-kernel/linux/files/systemd-dependencies.config

CONFIG_SECURITY_APPARMOR=y
CONFIG_DEFAULT_SECURITY="apparmor"
EOF
```


2. build core-image-minimal with systemd and apparmor
```
$: cat << EOF >> conf/local.conf
DISTRO_FEATURES_append = " pam"

VIRTUAL-RUNTIME_init_manager = "systemd"
DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
VIRTUAL-RUNTIME_initscripts = ""

IMAGE_INSTALL_append = " apparmor"
EOF
$: bitbake core-image-minimal
```


3. run qenu and start apparmor.service

```
$: runqemu nographic
....(snip)....
$: systemd start apparmor

```

## Test result

**Before this fix:**
```
$: systemd status apparmor
| ● apparmor.service - AppArmor initialization
|    Loaded: loaded (/lib/systemd/system/apparmor.service; disabled; vendor preset: enabled)
|    Active: failed (Result: exit-code) since Thu 2023-11-16 04:25:25 UTC; 10s ago
|      Docs: man:apparmor(7)
|            http://wiki.apparmor.net/
|   Process: 171 ExecStart=/etc/init.d/apparmor start (code=exited, status=203/EXEC)
|  Main PID: 171 (code=exited, status=203/EXEC)
|
| Nov 16 04:25:25 qemuarm64 systemd[1]: Starting AppArmor initialization...
| Nov 16 04:25:25 qemuarm64 systemd[171]: apparmor.service: Failed to execute command: No such file or directory
| Nov 16 04:25:25 qemuarm64 systemd[171]: apparmor.service: Failed at step EXEC spawning /etc/init.d/apparmor: No such file or directory
| Nov 16 04:25:25 qemuarm64 systemd[1]: apparmor.service: Main process exited, code=exited, status=203/EXEC
| Nov 16 04:25:25 qemuarm64 systemd[1]: apparmor.service: Failed with result 'exit-code'.
| Nov 16 04:25:25 qemuarm64 systemd[1]: Failed to start AppArmor initialization.
```


**After**

```
After:
| Nov 16 04:45:57 qemuarm64 systemd[1]: Starting AppArmor initialization...                                                                                   
| Nov 16 04:45:57 qemuarm64 apparmor[174]: Starting AppArmor profiles:find: '/etc/apparmor.d/cache': No such file or directory                                
| Nov 16 04:46:23 qemuarm64 apparmor[174]: .                                                                                                                  
| Nov 16 04:46:23 qemuarm64 systemd[1]: Started AppArmor initialization.
```