### PR TITLE
Set Cflags to use -I instead of -isystem

### DIFF
--- a/recipes-debian/libbsd/files/0001-Set-Cflags-to-use-I-instead-of-isystem.patch
+++ b/recipes-debian/libbsd/files/0001-Set-Cflags-to-use-I-instead-of-isystem.patch
@@ -1,0 +1,26 @@
+From d67481d1f4ea9967e567a4a473435552e9cc449b Mon Sep 17 00:00:00 2001
+From: Yoshihiro Okada <yoshihiro.okada@miraclelinux.com>
+Date: Thu, 21 Dec 2023 15:12:41 +0900
+Subject: [PATCH] Set Cflags to use -I instead of -isystem
+
+https://www.openembedded.org/pipermail/openembedded-core/2017-January/131998.html
+
+pkg-config currently only handles -I and -L correctly, but misses
+-isystem, so we need to do this workaround to fix this issue.
+---
+ src/libbsd-overlay.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libbsd-overlay.pc.in b/src/libbsd-overlay.pc.in
+index ac8bf89..5ec1107 100644
+--- a/src/libbsd-overlay.pc.in
++++ b/src/libbsd-overlay.pc.in
+@@ -8,4 +8,4 @@ Description: Utility functions from BSD systems (overlay)
+ Version: @VERSION@
+ URL: https://libbsd.freedesktop.org/
+ Libs: -L${libdir} -lbsd
+-Cflags: -isystem ${includedir}/bsd -DLIBBSD_OVERLAY
++Cflags: -I${includedir}/bsd -DLIBBSD_OVERLAY
+-- 
+2.25.1
+

--- a/recipes-debian/libbsd/libbsd_debian.bbappend
+++ b/recipes-debian/libbsd/libbsd_debian.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-Set-Cflags-to-use-I-instead-of-isystem.patch \
+"


### PR DESCRIPTION
# Purpose of pull request

Some system may fail to build packages which depends on libbsd package. This commit fix this issue.

See also  
https://www.openembedded.org/pipermail/openembedded-core/2017-January/131998.html

# Test
## How to test

Prepare ubuntu-20.04 environment and install libbsd-dev package as follows.

```
# apt-get install libbsd-dev
```

Using this environment, we can see following error when building libedit package without this commit.

```
ERROR: libedit-3.1-20181209-r0 do_configure: QA Issue: This autoconf log indicates errors, it looked at host include and/or library paths while determining system capabilities.
Rerun configure task after fixing this. [configure-unsafe]
ERROR: libedit-3.1-20181209-r0 do_configure: Fatal QA errors found, failing task.
ERROR: libedit-3.1-20181209-r0 do_configure: 
ERROR: libedit-3.1-20181209-r0 do_configure: Function failed: do_qa_configure
```

This commit fix this error.

## Test result
We can execute following build command without any error.

```
$ bitbake libedit
or
$ bitbake core-image-minimal
or
$ bitbake core-image-weston
```
