### PR TITLE
libnl: Add ptest

### DIFF
--- a/recipes-debian/libnl/files/enable-serial-tests.patch
+++ b/recipes-debian/libnl/files/enable-serial-tests.patch
@@ -1,0 +1,29 @@
+From b1476d89bf7a0bc6062438731ee4e9026696328b Mon Sep 17 00:00:00 2001
+From: Eric Xu <chi.xu@windriver.com>
+Date: Fri, 9 Mar 2018 03:38:49 +0000
+Subject: [PATCH] Add ptest for libnl
+
+serial-tests is required to generate those targets.
+
+Upstream-Status: Inappropriate [oe-specific]
+Signed-off-by: Eric Xu <chi.xu@windriver.com>
+---
+ configure.ac | 2 +-
+ 1 files changed, 1 insertion(+), 1 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index dfead98..2cc8257 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -46,7 +46,7 @@ AC_INIT(libnl, [libnl_version], [], [], [http://www.infradead.org/~tgr/libnl/])
+ AC_CONFIG_HEADERS([lib/defs.h])
+ AC_CONFIG_AUX_DIR([build-aux])
+ AC_CONFIG_MACRO_DIR([m4])
+-AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
++AM_INIT_AUTOMAKE([-Wall foreign subdir-objects serial-tests])
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)], [])
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ 
+-- 
+2.13.3
+

--- a/recipes-debian/libnl/files/run-ptest
+++ b/recipes-debian/libnl/files/run-ptest
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+num_fail=0
+
+for test in check*
+do
+    ./"$test" \
+         && echo "PASS: $test" \
+         || {
+            echo "FAIL: $test"
+            num_fail=$(( ${num_fail} + 1))
+         }
+
+done
+
+exit $num_fail


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of libnl package based on the following recipe:

* base recipe: [meta/recipes-support/libnl/libnl_3.5.0.bb](https://git.yoctoproject.org/poky/tree/meta/recipes-support/libnl/libnl_3.5.0.bb?id=b0130fcf91daee0d905af755302fabe608da141c)
* base branch: kirkstone
* base commit: b0130fcf91daee0d905af755302fabe608da141c

NOTE: This PR was originally created by @soenos, and reviewed and approved by @ML-HirotakaFurukawa at https://github.com/ML-HirotakaFurukawa/meta-debian-extended/pull/3 in advance.

# Test

## How to test

1.Enable ptest and install libnl package
```
$ . setup-emlinux
$ cat <<EOF >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " libnl"
EOF
```
 
2.Build core-image-minimal
```
$ bitbake core-image-minimal
```

3.Run qemu and execute ptest of libnl
```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner libnl
```

## Test result

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
acl     /usr/lib/acl/ptest/run-ptest
busybox /usr/lib/busybox/ptest/run-ptest
libnl3  /usr/lib/libnl3/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
root@qemuarm64:~# ptest-runner libnl3
START: ptest-runner
2023-12-26T07:58
BEGIN: /usr/lib/libnl3/ptest
Running suite(s): main
 Abstract addresses
 Netlink attributes
100%: Checks: 7, Failures: 0, Errors: 0
PASS: check-all
DURATION: 1
END: /usr/lib/libnl3/ptest
2023-12-26T07:58
STOP: ptest-runner
```

[ptest-libnl.log](https://github.com/miraclelinux/meta-debian-extended/files/13774326/ptest-libnl.log)

## Test summary

* TOTAL: 7
  * PASS: 7
  * FAIL: 0

I executed this ptest 3 times and obtained the same results.