### PR TITLE
target-sdk-provides-dummy: Add perl to DUMMYPROVIDES_remove

### DIFF
--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -23,6 +23,7 @@ DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'coreutils', '\
 		coreutils \
 		coreutils-dev \
 		coreutils-src \
+		perl \
 		', '', d)}"
 
 DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'bash', '\


### PR DESCRIPTION

# Purpose of pull request

When building SDK which contains bash and coreutils in its image, it will got following warning.

```
WARNING: core-image-minimal-sdk-1.0-r0 do_populate_sdk: Unable to install packages. Command '/home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal-sdk/1.0-r0/recipe-sysroot-native/usr/bin/apt-get  install --force-yes --allow-unauthenticated libcap-dbg libgcc-s-src perl-dev libz-dev bc-dbg sed-src kmod-dbg libgcc-s-dbg openssl-dbg opkg-utils-dbg make-dbg flex-src libreadline-src systemd-dev flex-dev systemd-dbg ncurses-src python-dev target-sdk-provides-dummy-dbg findutils-src acl-dbg util-linux-dev update-rc.d-dev bison-src shadow-securetty-dbg base-passwd-dbg bison-dev packagegroup-core-boot-dbg bc-src util-linux-dbg attr-src coreutils-dbg target-sdk-provides-dummy-dev findutils-dbg util-linux-src libz-src kernel-devsrc-dbg libgmp-dbg bash-dbg bash-src glibc-locale-dbg libgmp-src shadow-dbg liberror-perl-dbg python-dbg netbase-dev sed-dbg run-postinsts-dev base-passwd-src systemd-src glibc-src flex-dbg packagegroup-core-standalone-sdk-target-dbg run-postinsts-dbg acl-src bc-dev kmod-src kmod-dev shadow-src initscripts-dbg packagegroup-core-standalone-sdk-target-dev m4-dbg libcap-src perl-dbg m4-dev openssl-src gawk-src m4-src python-src gcc-runtime-dbg packagegroup-core-boot-dev make-src perl-src coreutils-src bison-dbg gawk-dbg libreadline-dbg attr-dbg libz-dbg base-files-dbg update-rc.d-dbg kernel-devsrc-dev netbase-dbg initscripts-dev ncurses-dbg' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have requested an impossible situation or if you are using the unstable distribution that some required packages have not yet been created or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 packagegroup-core-boot-dev : Depends: packagegroup-core-boot (= 1.0-r17) but it is not going to be installed
                              Recommends: busybox-dev
                              Recommends: busybox-hwclock-dev but it is not installable
                              Recommends: udev-dev but it is not installable
                              Recommends: update-alternatives-opkg-dev but it is not installable
 target-sdk-provides-dummy-dev : Depends: target-sdk-provides-dummy (= 1.0-r0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

The coreutils-ptest package has runtime dependency on perl so that it needs to remove perl package from DUMMYPROVIDES.

# Test
## How to test

1. Add `IMAGE_INSTALL_append = " bash coreutils"` to conf/local.conf
2. Run `bitbake core-image-minimal-sdk -c populate_sdk'

## Test result

SDK can be built without any warnings.

```
┌──build@2c07576fd524:~/work/emlinux/latest-dev/build                                              
└─$ bitbake core-image-minimal-sdk -c populate_sdk                                                 
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:17
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2382 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies                                                
                                                                                                   
Build Configuration:                                                                               
BB_VERSION           = "1.42.0"                                                                    
BUILD_SYS            = "x86_64-linux"                                                              
NATIVELSBSTRING      = "ubuntu-18.04"                                                              
TARGET_SYS           = "aarch64-emlinux-linux"                                                     
MACHINE              = "qemuarm64"                                                                 
DISTRO               = "emlinux"                                                                   
DISTRO_VERSION       = "2.8"                                                                       
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:1a52e264d5434fd23f907f6d01d3458f5512a595"
meta-debian-extended = "fix-coreutils-sdkbuild:6e885d4f6573fad165390bb8fcaa25b75b2659b0"
meta-emlinux         = "HEAD:5e1dedffb1741f73e2208f981a7a03ce4f70986e"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 829 Found 0 Missed 829 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3395 tasks of which 0 didn't need to be rerun and all succeeded.
```




