### PR TITLE
Revert "Merge pull request #453 from masami256/fix-coreutils-sdkbuild"

### DIFF
--- a/recipes-core/meta/target-sdk-provides-dummy.bbappend
+++ b/recipes-core/meta/target-sdk-provides-dummy.bbappend
@@ -23,7 +23,6 @@ DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'coreutils', '\
 		coreutils \
 		coreutils-dev \
 		coreutils-src \
-		perl \
 		', '', d)}"
 
 DUMMYPROVIDES_remove = "${@bb.utils.contains('IMAGE_INSTALL', 'bash', '\


### PR DESCRIPTION
This reverts commit 1cdf1e1bf63bf2c14f12865147e44ef7ee238f0d, reversing changes made to 52e99ebf83b50d7d905fd0cff02a17e785d1b0b7.

To fix SDK build error, it can be done with https://github.com/miraclelinux/meta-debian/pull/83 so we should revert 1cdf1e1bf63.


