### PR TITLE
bluez5: Add CVE-2020-24490 to whitelist

### DIFF
--- a/recipes-debian/bluez5/bluez5_debian.bb
+++ b/recipes-debian/bluez5/bluez5_debian.bb
@@ -23,6 +23,9 @@ SRC_URI += "\
 
 REQUIRED_DISTRO_FEATURES = "bluez5"
 
+# CVE-2020-24490: Fixed with kernel changes and don't affect the bluez recipe.
+CVE_CHECK_WHITELIST = "CVE-2020-24490"
+
 # noinst programs in Makefile.tools that are conditional on READLINE
 # support
 NOINST_TOOLS_READLINE ?= " \


### PR DESCRIPTION
The CVE-2020-24490 is fixed with kernel changes and don't affect the bluez5 recipe.

https://nvd.nist.gov/vuln/detail/CVE-2020-24490
https://security-tracker.debian.org/tracker/CVE-2020-24490

Referenced from Poky-dunfell rev: f9a754faa64e419e3a3590f136372ae765477236
