### PR TITLE
whois: Fix conflict of mkpasswd

### DIFF
--- a/recipes-debian/whois/whois_debian.bb
+++ b/recipes-debian/whois/whois_debian.bb
@@ -9,7 +9,7 @@ DEPENDS += "gettext-native libidn"
 
 # give higher priority to whois package than inetutils one.
 ALTERNATIVE_PRIORITY = "80"
-ALTERNATIVE_${PN} = "whois"
+ALTERNATIVE_${PN} = "whois mkpasswd"
 
 do_install() {
     oe_runmake "BASEDIR=${D}" install


### PR DESCRIPTION
# Purpose of pull request

This PR aims to fix conflict of mkpasswd.

mkpasswd is provided by multiple sources, for example, whois and expect.

However, `whois_debian.bb` doesn't set proper value to `ALTERNATIVE` variable. This results in the following error when building an image with whois and expect:
```
$ cat <<EOF >> conf/local.conf

MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " whois expect"
EOF
$ bitbake core-image-minimal
Parsing recipes: 100% |#######################################################################################################################| Time: 0:00:06
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2384 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:132d52b7e266ca89b07f4313840541887748a2fb"
meta-debian-extended = "HEAD:b0bdd3911a4bd546d05a65e739082a517bce3fe2"
meta-emlinux         = "HEAD:7c37b42fb8d0e2882625c2dbed86bbb4667de9eb"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |####################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 647 Found 21 Missed 626 Current 241 (3% match, 29% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: core-image-minimal-1.0-r0 do_rootfs: Postinstall for package expect failed with 1:
update-alternatives: Error: not linking /home/miyazaki/Projects/workspace-emlinux2/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/rootfs/usr/bin/mkpasswd to /usr/bin/mkpasswd.expect since /home/miyazaki/Projects/workspace-emlinux2/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/rootfs/usr/bin/mkpasswd exists and is not a link

ERROR: core-image-minimal-1.0-r0 do_rootfs: Postinstall scriptlets of ['expect'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
Details of the failure are in /home/miyazaki/Projects/workspace-emlinux2/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/temp/log.do_rootfs.
ERROR: core-image-minimal-1.0-r0 do_rootfs:
ERROR: core-image-minimal-1.0-r0 do_rootfs: Function failed: do_rootfs
ERROR: Logfile of failure stored in: /home/miyazaki/Projects/workspace-emlinux2/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/temp/log.do_rootfs.221050
ERROR: Task (/home/miyazaki/Projects/workspace-emlinux2/build/../repos/poky/meta/recipes-core/images/core-image-minimal.bb:do_rootfs) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3103 tasks of which 1399 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/miyazaki/Projects/workspace-emlinux2/build/../repos/poky/meta/recipes-core/images/core-image-minimal.bb:do_rootfs
Summary: There was 1 WARNING message shown.
Summary: There were 3 ERROR messages shown, returning a non-zero exit code.
```

According to whois' [README](https://github.com/rfc1036/whois/blob/ca6d0c6307239315ed8de720f662fc6780a2b46c/README#L11), it contains mkpasswd for "historical reasons". 

## How to test

1. Append the following in `conf/local.conf`
```
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " whois expect"
```
2. Build an image.

## Test result

```
$ cat <<EOF >> conf/local.conf

MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " whois expect"
EOF
$ bitbake core-image-minimal
Loading cache: 100% |#########################################################################################################################| Time: 0:00:00
Loaded 2384 entries from dependency cache.
Parsing recipes: 100% |#######################################################################################################################| Time: 0:00:00
Parsing of 1362 .bb files complete (1361 cached, 1 parsed). 2384 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:132d52b7e266ca89b07f4313840541887748a2fb"
meta-debian-extended = "fix-whois:a1f55065d2bcfc74b96c0df4db5b5c9e90c6b450"
meta-emlinux         = "HEAD:7c37b42fb8d0e2882625c2dbed86bbb4667de9eb"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |####################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 6 Found 0 Missed 6 Current 882 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3111 tasks of which 3097 didn't need to be rerun and all succeeded.
```



