### PR TITLE
openvpn: Set CVE_PRODUCT

### DIFF
--- a/recipes-debian/openvpn/openvpn_debian.bb
+++ b/recipes-debian/openvpn/openvpn_debian.bb
@@ -9,6 +9,8 @@ LICENSE = "GPL-2.0-with-OpenSSL-exception & BSD-2-Clause & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7aee596ed2deefe3e8a861e24292abba"
 DEPENDS = "lzo openssl iproute2 ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
 
+CVE_PRODUCT = "openvpn:openvpn"
+
 inherit debian-package
 require recipes-debian/sources/openvpn.inc
 


### PR DESCRIPTION
# Purpose of pull request

This PR sets `CVE_PRODUCT` in openvpn recipe to prevent false-positive CVEs.

Currently cve-check has identified CVE-2020-7224 and CVE-2020-27569 as vulnerabilities of openvpn,
but they are not for us and are therefore false-positives.

```
$ cat << EOS >> conf/local.conf
MACHINE = "qemuarm64"
INHERIT += "cve-check"
EOS
$ bitbake openvpn -c cve_check
...(snip)...
WARNING: openvpn-2.4.7-r0 do_cve_check: Found unpatched CVE (CVE-2020-11810 CVE-2020-15078 CVE-2020-20813 CVE-2020-27569 CVE-2020-7224 CVE-2021-3606 CVE-2022-0547), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/openvpn/2.4.7-r0/temp/cve.log
```

To prevent current and future false-positives, set CVE_PRODUCT.

# Test
## How to test

Run following command from console in build environment

```
$ cat << EOS >> conf/local.conf
MACHINE = "qemuarm64"
INHERIT += "cve-check"
EOS
$ bitbake openvpn -c cve_check
```

Confirm that the false-positive CVEs are not detected.

## Test result

```
$ bitbake openvpn -c cve_check
...(snip)...
WARNING: openvpn-2.4.7-r0 do_cve_check: Found unpatched CVE (CVE-2020-11810 CVE-2020-15078 CVE-2020-20813 CVE-2021-3606 CVE-2022-0547), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/openvpn/2.4.7-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

CVE-2020-7224 and CVE-2020-27569 are not shown.

Also, I confirmed that `bitbake core-image-minimal` and `bitbake core-image-minimal-sdk -c populate_sdk` succeeds.