### PR TITLE
libjpeg-turbo: Add patch to fix CVE-2020-17541

### DIFF
--- a/recipes-debian/jpeg/libjpeg-turbo/CVE-2020-17541.patch
+++ b/recipes-debian/jpeg/libjpeg-turbo/CVE-2020-17541.patch
@@ -1,0 +1,46 @@
+From 64e870258c63e0fe2630218fc7801e91610e7eaa Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Thu, 5 Dec 2019 13:12:28 -0600
+Subject: [PATCH] Huffman enc.: Fix very rare local buffer overrun
+
+... detected by ASan.  This is a similar issue to the issue that was
+fixed with 402a715f82313384ef4606660c32d8678c79f197.  Apparently it is
+possible to create a malformed JPEG image that exceeds the Huffman
+encoder's 256-byte local buffer when attempting to losslessly tranform
+the image.  That makes sense, given that it was necessary to extend the
+Huffman decoder's local buffer to 512 bytes in order to handle all
+pathological cases (refer to 0463f7c9aad060fcd56e98d025ce16185279e2bc.)
+
+Since this issue affected only lossless transformation, a workflow that
+isn't generally exposed to arbitrary data exploits, and since the
+overrun did not overflow the stack (i.e. it did not result in a segfault
+or other user-visible issue, and valgrind didn't even detect it), it did
+not likely pose a security risk.
+
+Fixes #392
+---
+ jchuff.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/jchuff.c b/jchuff.c
+index fffaace..78cca73 100644
+--- a/jchuff.c
++++ b/jchuff.c
+@@ -4,7 +4,7 @@
+  * This file was part of the Independent JPEG Group's software:
+  * Copyright (C) 1991-1997, Thomas G. Lane.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2009-2011, 2014-2016, D. R. Commander.
++ * Copyright (C) 2009-2011, 2014-2016, 2018-2019, D. R. Commander.
+  * Copyright (C) 2015, Matthieu Darbois.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+@@ -428,7 +428,7 @@ dump_buffer (working_state *state)
+  * scanning order-- 1, 8, 16, etc.), then this will produce an encoded block
+  * larger than 200 bytes.
+  */
+-#define BUFSIZE (DCTSIZE2 * 4)
++#define BUFSIZE (DCTSIZE2 * 8)
+ 
+ #define LOAD_BUFFER() { \
+   if (state->free_in_buffer < BUFSIZE) { \

--- a/recipes-debian/jpeg/libjpeg-turbo_debian.bb
+++ b/recipes-debian/jpeg/libjpeg-turbo_debian.bb
@@ -10,6 +10,8 @@ inherit debian-package
 require recipes-debian/sources/libjpeg-turbo.inc
 FILESPATH_append = ":${COREBASE}/meta/recipes-graphics/jpeg/files"
 
+SRC_URI += " file://CVE-2020-17541.patch"
+
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://cdjpeg.h;endline=13;md5=05bab7c7ad899d85bfba60da1a1271f2 \
                     file://jpeglib.h;endline=16;md5=f67d70e547a2662c079781c72f877f72 \


### PR DESCRIPTION
# Purpose of pull request

Backport the following commit to fix CVE-2020-17541
- [6bbc0a3c7](https://github.com/libjpeg-turbo/libjpeg-turbo/commit/6bbc0a3c703f5ea2aecc3a6e60e8ba2935febb82) Huffman enc.: Fix very rare local buffer overrun

# Test

1. Build package
2. Run cve-check and compare the results
3. Run image and test the packages on the qemuarm64 environment (Package Test)

## How to test the package

3-1. Build qemuarm64 image
3-2. Prepare patched libjpeg-turbo source code
3-3. Run qemu image
3-4. Take libjpeg-turbo source code directory
3-5. Build the libjpeg-turbo library
3-6. Replace some binaries to make sure that installed binaries are used in test
3-7. Run libjpeg-turbo test

### 3-1. Build qemuarm64 image

Add the following to local.conf and build qemuarm64 image

```
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " libjpeg-turbo jpeg-tools libturbojpeg openssh make"
EXTRA_IMAGE_FEATURES_append = " tools-sdk"
IMAGE_ROOTFS_EXTRA_SPACE = "2097152"
```

```
$ bitbake core-image-minimal
```

### 3-2. Prepare patched libjpeg-turbo source code

```
$ bitbake -c cleanall libjpeg-turbo
$ bitbake -c patch libjpeg-turbo
```

### 3-3. Run qemu image

```
$ runqemu qemuarm64 nographic
```

### 3-4. Take libjpeg-turbo source code directory

Take the libjpeg-turbo source code directory (`tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/libjpeg-turbo-1.5.2/`) to the running qemu environment using scp

```
$ scp -r tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/libjpeg-turbo-1.5.2/ <USER>@<HOST>:~/
```

### 3-5. Build the libjpeg-turbo library

Build the libjpeg-turbo library to build Makefile and test scripts

```
# cd libjpeg-turbo-1.5.2
# autoreconf -vif
# ./configure
# make all
```

### 3-6. Replace some binaries to make sure installed binaries are used in test

Create symlink to already installed binaries

```
# ln -sf /usr/bin/tjbench
# ln -sf /usr/bin/cjpeg
# ln -sf /usr/bin/djpeg
# ln -sf /usr/bin/jpegtran
```

Copy binaries which are not installed in rootfs

```
$ scp tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/build/.libs/tjunittest <USER>@<HOST>:~/libjpeg-turbo-1.5.2/
$ scp tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/build/md5/md5cmp <USER>@<HOST>:~/libjpeg-turbo-1.5.2/md5/
```

### 3-7. Run libjpeg-turbo test

```
# make test
```

## Test result

### 1. Build package

Build succeeded.

```
$ bitbake libjpeg-turbo
Loading cache: 100% |#############################################################################################################################################################################| Time: 0:00:00
Loaded 2378 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:290a265aa6ae2efda35b9f4a42853223555b488b"
meta-debian-extended = "libjpeg-turbo-fix-CVE-2020-17541:c47c5d84e6e8472bbe1429ebccb9e38fb081249c"
meta-emlinux         = "HEAD:e0d9964c1d66d1440f335e26ceda0c385fafecac"

Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 11 Found 5 Missed 6 Current 71 (45% match, 92% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 601 tasks of which 585 didn't need to be rerun and all succeeded.
```


### 2. Run cve-check

Before applying this patch:

```
$ bitbake -c cve_check libjpeg-turbo

...(snip)...

WARNING: libjpeg-turbo-1_1.5.2-r0 do_cve_check: Found unpatched CVE (CVE-2017-15232 CVE-2018-14498 CVE-2020-17541), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

CVE-2020-17541 is shown.

After applying this patch:

```
$ bitbake -c cve_check libjpeg-turbo

...(snip)...

WARNING: libjpeg-turbo-1_1.5.2-r0 do_cve_check: Found unpatched CVE (CVE-2017-15232 CVE-2018-14498), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

CVE-2020-17541 is not shown.

### 3. Package test

All tests succeeded.

```
root@qemuarm64:~/libjpeg-turbo-1.5.2# make test

...(snip)...

md5/md5cmp cb57b32bd6d03e35432362f7bf184b6d testout_444_islow_ari_crop37x37,0,0.ppm
testout_444_islow_ari_crop37x37,0,0.ppm: OK
rm -f testout_444_islow_ari_crop37x37,0,0.ppm
rm -f testout_444_islow_ari.jpg
./jpegtran -crop 120x90+20+50 -transpose -perfect -outfile testout_crop.jpg ./testimages/testorig.jpg
md5/md5cmp b4197f377e621c4e9b1d20471432610d testout_crop.jpg
testout_crop.jpg: OK
rm -f testout_crop.jpg
echo GREAT SUCCESS!
GREAT SUCCESS!
```

[libjpeg-turbo-test.log](https://github.com/miraclelinux/meta-debian-extended/files/15036981/libjpeg-turbo-test.log)