### PR TITLE
busybox: Add patch to fix CVE-2022-48174

### DIFF
--- a/recipes-debian/busybox/busybox/CVE-2022-48174.patch
+++ b/recipes-debian/busybox/busybox/CVE-2022-48174.patch
@@ -1,0 +1,79 @@
+From ea092449f2dc87bbc2c150f3ee87cb80648d1c9a Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Mon, 12 Jun 2023 17:48:47 +0200
+Subject: [PATCH] shell: avoid segfault on ${0::0/0~09J}. Closes 15216
+
+function                                             old     new   delta
+evaluate_string                                     1011    1053     +42
+
+CVE: CVE-2022-48174
+Upstream-Status: Backport [d417193cf37ca1005830d7e16f5fa7e1d8a44209]
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ shell/math.c | 39 +++++++++++++++++++++++++++++++++++----
+ 1 file changed, 35 insertions(+), 4 deletions(-)
+
+diff --git a/shell/math.c b/shell/math.c
+index 611b3be..5d1ebaf 100644
+--- a/shell/math.c
++++ b/shell/math.c
+@@ -467,6 +467,28 @@ arith_apply(arith_state_t *math_state, operator op, var_or_num_t *numstack, var_
+ #undef NUMPTR
+ }
+ 
++//TODO: much better estimation than expr_len/2? Such as:
++//static unsigned estimate_nums_and_names(const char *expr)
++//{
++//	unsigned count = 0;
++//	while (*(expr = skip_whitespace(expr)) != '\0') {
++//		const char *p;
++//		if (isdigit(*expr)) {
++//			while (isdigit(*++expr))
++//				continue;
++//			count++;
++//			continue;
++//		}
++//		p = endofname(expr);
++//		if (p != expr) {
++//			expr = p;
++//			count++;
++//			continue;
++//		}
++//	}
++//	return count;
++//}
++
+ /* longest must be first */
+ static const char op_tokens[] ALIGN1 = {
+ 	'<','<','=',0, TOK_LSHIFT_ASSIGN,
+@@ -520,10 +542,12 @@ evaluate_string(arith_state_t *math_state, const char *expr)
+ 	const char *errmsg;
+ 	const char *start_expr = expr = skip_whitespace(expr);
+ 	unsigned expr_len = strlen(expr) + 2;
+-	/* Stack of integers */
+-	/* The proof that there can be no more than strlen(startbuf)/2+1
+-	 * integers in any given correct or incorrect expression
+-	 * is left as an exercise to the reader. */
++	/* Stack of integers/names */
++	/* There can be no more than strlen(startbuf)/2+1
++	 * integers/names in any given correct or incorrect expression.
++	 * (modulo "09v09v09v09v09v" case,
++	 * but we have code to detect that early)
++	 */
+ 	var_or_num_t *const numstack = alloca((expr_len / 2) * sizeof(numstack[0]));
+ 	var_or_num_t *numstackptr = numstack;
+ 	/* Stack of operator tokens */
+@@ -592,6 +616,13 @@ evaluate_string(arith_state_t *math_state, const char *expr)
+ 			numstackptr->var = NULL;
+ 			errno = 0;
+ 			numstackptr->val = strto_arith_t(expr, (char**) &expr, 0);
++			/* A number can't be followed by another number, or a variable name.
++			 * We'd catch this later anyway, but this would require numstack[]
++			 * to be twice as deep to handle strings where _every_ char is
++			 * a new number or name. Example: 09v09v09v09v09v09v09v09v09v
++			 */
++			if (isalnum(*expr) || *expr == '_')
++				goto err;
+ 			if (errno)
+ 				numstackptr->val = 0; /* bash compat */
+ 			goto num;

--- a/recipes-debian/busybox/busybox_%.bbappend
+++ b/recipes-debian/busybox/busybox_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://CVE-2022-48174.patch"


### PR DESCRIPTION
# Purpose of pull request

This PR fixes CVE-2022-48174.

Backport the following commit from poky's dunfell:
- [3ee56c9b97](https://git.yoctoproject.org/poky/commit/?h=dunfell&id=3ee56c9b975efc22fd535879d2ab6aaa7c67e1a7) busybox: Backport CVE-2022-48174 fix

# Test

1. Build package
2. Run cve-check and compare the results
3. Run image and test the packages on the qemuarm64 environment (Package Test)

## How to test the package

### 3-1. Build qemuarm64 image

Add the following to local.conf and build qemuarm64 image

```
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " busybox"
```

### 3-2. Run qemu image

```
$ runqemu nographic slirp
```

### 3-3. Run ptest of busybox

```
# ptest-runner -t 3600 busybox  | tee ptest-busybox.log
# grep -c '^PASS: ' ptest-busybox.log
# grep -c '^FAIL: ' ptest-busybox.log
```

## Test result

### 1. Build package

```
$ bitbake busybox
Loading cache: 100% |#############################################################################################################################################################################| Time: 0:00:00
Loaded 2378 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:ab5a904a98edd21a8834c21b0d12497e8be306cc"
meta-debian-extended = "busybox-fix-CVE-2022-48174:4a66dba39d7bb44f6ea65f83e4a55bfec34d4a36"
meta-emlinux         = "HEAD:e0d9964c1d66d1440f335e26ceda0c385fafecac"

Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 8 Found 2 Missed 6 Current 436 (25% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2054 tasks of which 2035 didn't need to be rerun and all succeeded.
```

### 2. Run cve-check and compare the results

Before applying this patch:

```
$ bitbake -c cve_check busybox

...(snip)...

WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-28391 CVE-2022-48174 CVE-2023-39810), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

CVE-2022-48174 is shown.

After applying this patch:

```
$ bitbake -c cve_check busybox

...(snip)...

WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-28391 CVE-2023-39810), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

CVE-2022-48174 is not shown.

### 3. Run ptest of busybox

```
root@qemuarm64:~# ptest-runner -t 3600 busybox | tee ptest-busybox.log
START: ptest-runner
2024-04-23T00:22
BEGIN: /usr/lib/busybox/ptest
======================
echo -ne '' >input
echo -ne '' | ./unknown 2>&1
PASS: busybox as unknown name
SKIP: busybox --help busybox
======================
...(snip)...
======================
echo -ne '' >input
echo -ne '2 3 4 5 6 7 8 9 0 2 3 4 5 6 7 8 9 00\n' | xargs -ts25 echo 1 2>&1 >/dev/null
PASS: xargs -sNUM test 2
DURATION: 112
END: /usr/lib/busybox/ptest
2024-04-23T00:24
STOP: ptest-runner
root@qemuarm64:~# grep -c '^PASS: ' ptest-busybox.log
533
root@qemuarm64:~# grep -c '^FAIL: ' ptest-busybox.log
0
```

[busybox-test.log](https://github.com/miraclelinux/meta-debian-extended/files/15069837/busybox-test.log)