### PR TITLE
expect: Fix path name buffer overflow

### DIFF
--- a/recipes-debian/expect/expect_debian.bb
+++ b/recipes-debian/expect/expect_debian.bb
@@ -29,6 +29,7 @@ FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/expect/expect"
 SRC_URI += "file://0001-configure.in.patch \
             file://0002-tcl.m4.patch \
             file://0001-expect-install-scripts-without-using-the-fixline1-tc.patch \
+            file://0001-exp_main_sub.c-Use-PATH_MAX-for-path.patch \
            "
 
 UPSTREAM_CHECK_URI = "http://sourceforge.net/projects/expect/files/Expect/"

--- a/recipes-debian/expect/files/0001-exp_main_sub.c-Use-PATH_MAX-for-path.patch
+++ b/recipes-debian/expect/files/0001-exp_main_sub.c-Use-PATH_MAX-for-path.patch
@@ -1,0 +1,55 @@
+From 1407fcad6f1dac0a4efe8041660bf6139c1cd16a Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Tue, 24 Sep 2019 13:40:10 +0800
+Subject: [PATCH] exp_main_sub.c: Use PATH_MAX for path
+
+If expect was built from a long path whose length > 200, then it couldn't run:
+$ expect -c 'puts yes'
+*** buffer overflow detected ***: expect terminated
+Aborted (core dumped)
+
+Use PATH_MAX to fix the problem.
+
+Upstream-Status: Pending [Upstream seems dead]
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ exp_main_sub.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/exp_main_sub.c b/exp_main_sub.c
+index fcfaa6e..bf6c4be 100644
+--- a/exp_main_sub.c
++++ b/exp_main_sub.c
+@@ -48,6 +48,10 @@ char exp_version[] = PACKAGE_VERSION;
+ #define NEED_TCL_MAJOR		7
+ #define NEED_TCL_MINOR		5
+ 
++#ifndef PATH_MAX
++#define PATH_MAX 4096
++#endif
++
+ char *exp_argv0 = "this program";	/* default program name */
+ void (*exp_app_exit)() = 0;
+ void (*exp_event_exit)() = 0;
+@@ -901,7 +905,7 @@ int sys_rc;
+ 	int rc;
+ 
+ 	if (sys_rc) {
+-	    char file[200];
++	    char file[PATH_MAX];
+ 	    int fd;
+ 
+ 	    sprintf(file,"%s/expect.rc",SCRIPTDIR);
+@@ -917,7 +921,7 @@ int sys_rc;
+ 	    }
+ 	}
+ 	if (my_rc) {
+-	    char file[200];
++	    char file[PATH_MAX];
+ 	    char *home;
+ 	    int fd;
+ 	    char *getenv();
+-- 
+2.7.4
+


### PR DESCRIPTION
# Purpose of pull request

If expect was built from large path which is greater than 200 bytes, it causes buffer overflow.
For example, build directory is
"/buildbot/build_daily_find_latest_src_qemuarm64_truly_latest_public/build/build_qemuarm64_deby_core-image-minimal".

To fixed this problem, import a patch from poky dunfell branch (https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/expect/expect/0001-exp_main_sub.c-Use-PATH_MAX-for-path.patch?h=dunfell&id=63d05fc061006bf1a88630d6d91cdc76ea33fbf2).

# Test
## How to test

Run expect-native's expect command.
e.g. /buildbot/build_daily_find_latest_src_qemuarm64_truly_latest_public/build/build_qemuarm64_deby_core-image-minimal/tmp/work/x86_64-linux/dejagnu-native/1.6.2-r0/recipe-sysroot-native/usr/bin/expect

## Test result

Before applying the patch, expect crashes.

```
$
/buildbot/build_daily_find_latest_src_qemuarm64_truly_latest_public/build/build_qemuarm64_deby_core-image-minimal/tmp/work/x86_64-linux/dejagnu-native/1.6.2-r0/recipe-sysroot-native/usr/bin/expect
*** buffer overflow detected ***: terminated
Aborted (core dumped)
```

After applying the patch, expect works fine.

```
$
/buildbot/build_daily_find_latest_src_qemuarm64_truly_latest_public/build/build_qemuarm64_deby_core-image-minimal/tmp/work/x86_64-linux/dejagnu-native/1.6.2-r0/recipe-sysroot-native/usr/bin/expect
expect1.1>
```


