### PR TITLE
Add PR variable for CVE patch

### DIFF
--- a/recipes-debian/busybox/busybox_%.bbappend
+++ b/recipes-debian/busybox/busybox_%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+PR = "r1"
+
 SRC_URI += "file://CVE-2022-48174.patch"

--- a/recipes-debian/jpeg/libjpeg-turbo_debian.bb
+++ b/recipes-debian/jpeg/libjpeg-turbo_debian.bb
@@ -10,6 +10,8 @@ inherit debian-package
 require recipes-debian/sources/libjpeg-turbo.inc
 FILESPATH_append = ":${COREBASE}/meta/recipes-graphics/jpeg/files"
 
+PR = "r1"
+
 SRC_URI += " file://CVE-2020-17541.patch"
 
 LICENSE = "BSD-3-Clause"


### PR DESCRIPTION
# Purpose of pull request

This PR adds `PR` variable for CVE-2022-48174 (busybox) and CVE-2020-17541 (libjpeg-turbo), in order to make it easy to distinguish whether CVE patch is applied or not.

# Test
## How to test

Confirm building core-image-minimal image and SDK successfully.
And, run `bitbake -e` and `ls tmp-glibc/work/aarch64-emlinux-linux/<package name>` to confim `PR` is set correctly.

1. Run following commands to build image and SDK
```
. setup-emlinux
cat << 'EOS' >> conf/local.conf
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " busybox libjpeg-turbo"
EOS
bitbake core-image-minimal
bitbake core-image-minimal-sdk -c populate_sdk
```

2. Run the following commands to check `PR` variable
```
bitbake -e busybox | grep 'PR='
bitbake -e libjpeg-turbo | grep 'PR='
ls tmp-glibc/work/aarch64-emlinux-linux/busybox/
ls tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/
```

## Test result

1. Build succeeded
```
$ bitbake core-image-minimal
Loading cache: 100% |#############################################################################################################################################################################| Time: 0:00:00
Loaded 2377 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:49224ba5e9678793264be2e7e67b7754ab0836cb"
meta-debian-extended = "increment-pr-for-cve-patch:b91c5728562abd3c7de4f10bece28dc63acbd5b1"
meta-emlinux         = "HEAD:d26135353218f4a9da51a3c51de7275cb21d989c"

Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 3 Found 0 Missed 3 Current 867 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3066 tasks of which 3052 didn't need to be rerun and all succeeded.
```

```
$ bitbake core-image-minimal-sdk -c populate_sdk
Loading cache: 100% |#############################################################################################################################################################################| Time: 0:00:00
Loaded 2377 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:49224ba5e9678793264be2e7e67b7754ab0836cb"
meta-debian-extended = "increment-pr-for-cve-patch:b91c5728562abd3c7de4f10bece28dc63acbd5b1"
meta-emlinux         = "HEAD:d26135353218f4a9da51a3c51de7275cb21d989c"

Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 339 Found 0 Missed 339 Current 496 (0% match, 59% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3425 tasks of which 2715 didn't need to be rerun and all succeeded.
```

2. `PR` was set correctly.
```
$ bitbake -e busybox | grep 'PR='
PR="r1"
$ bitbake -e libjpeg-turbo | grep 'PR='
PR="r1"
$ ls tmp-glibc/work/aarch64-emlinux-linux/busybox/
1.30.1-r1
$ ls tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/
1_1.5.2-r1
```