### PR TITLE
apparmor: Disable apparmor-ptest

### DIFF
--- a/recipes-debian/AppArmor/apparmor_debian.bb
+++ b/recipes-debian/AppArmor/apparmor_debian.bb
@@ -17,7 +17,17 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=fd57a4b0bc782d7b80fd431f10bbf9d0"
 
 DEPENDS = "bison-native apr gettext-native coreutils-native"
 
-inherit pkgconfig autotools-brokensep update-rc.d python3native perlnative ptest cpan manpages systemd debian-package
+inherit pkgconfig autotools-brokensep update-rc.d python3native perlnative cpan manpages systemd debian-package
+# FIXME:
+#   Building apparmor-ptest will fail regardless of TARGET_ARCH because Makefile
+#   for apparmor's tests does not support cross-compilation.
+#   Some targets are failed to build even though HOST_ARCH and TARGET_ARCH are
+#   the same.
+#   This recipe will not build and install for ptest if ARCH is aarch64 or arm,
+#   but 'inherit ptest' remains to apparmor-ptest package will be created that
+#   only contains the 'run-ptest' file.
+#   So, remove ptest from inherit because it is not a available quality.
+#inherit ptest
 
 SRC_URI += " \
         file://disable_perl_h_check.patch \


### PR DESCRIPTION
# Purpose of pull request
Disable apparmor-ptest because it fails to build regardless of TARGET_ARCH. And, add FIXME comment for this reason.


# Build test
## How to test
1. apparmor
   ```
   $ bitbake apparmor
   ```

2. apparmor-ptest
   ```
   $ bitbake apparmor-ptest
   ```

## Test result
### apparmor
The apparmor built successfully.
```
build$ bitbake apparmor
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:00:51
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2381 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:ebb4b2fa547f1f1dd79c03fb4e5bc5f65d855c98"
meta-debian-extended = "disable-apparmor-ptest:0d9c563609a4a104ebedeabbcfab99648ad4faea"
meta-emlinux         = "HEAD:4b3bfebbbb90ccbc921436e86ba45595e9b10b36"
meta-emlinux-private = "HEAD:3534c7782ba150055729db6720e5c10264c2d0e7"

Initialising tasks: 100% |#######################################################################################################################################################################################################################################| Time: 0:00:07
Sstate summary: Wanted 457 Found 0 Missed 457 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2118 tasks of which 0 didn't need to be rerun and all succeeded.
```

### apparmor-ptest
The apparmor-ptest does not exist.
```
build$ bitbake apparmor-ptest
Loading cache: 100% |############################################################################################################################################################################################################################################| Time: 0:00:00
Loaded 2381 entries from dependency cache.
ERROR: Nothing PROVIDES 'apparmor-ptest'. Close matches:
  apparmor

Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```