### PR TITLE
tiff: Add patch to fix CVE-2024-7006

### DIFF
--- a/recipes-debian/libtiff/files/CVE-2024-7006.patch
+++ b/recipes-debian/libtiff/files/CVE-2024-7006.patch
@@ -1,0 +1,66 @@
+From 818fb8ce881cf839fbc710f6690aadb992aa0f9e Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 1 Dec 2023 20:12:25 +0100
+Subject: [PATCH] Check return value of _TIFFCreateAnonField().
+
+Fixes #624
+
+CVE: CVE-2024-7006
+Upstream-Status: Backport [https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce881cf839fbc710f6690aadb992aa0f9e]
+Comments: Refreshed Hunk
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+
+---
+ libtiff/tif_dirinfo.c |  2 +-
+ libtiff/tif_dirread.c | 16 ++++++----------
+ 2 files changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/libtiff/tif_dirinfo.c b/libtiff/tif_dirinfo.c
+index a59b1da..65b7caf 100644
+--- a/libtiff/tif_dirinfo.c
++++ b/libtiff/tif_dirinfo.c
+@@ -623,7 +623,7 @@ _TIFFFindOrRegisterField(TIFF *tif, uint32 tag, TIFFDataType dt)
+ 	fld = TIFFFindField(tif, tag, dt);
+ 	if (fld == NULL) {
+ 		fld = _TIFFCreateAnonField(tif, tag, dt);
+-		if (!_TIFFMergeFields(tif, fld, 1))
++		if (fld == NULL || !_TIFFMergeFields(tif, fld, 1))
+ 			return NULL;
+ 	}
+ 
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 4ef26dc..f68c667 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -3700,11 +3700,9 @@ TIFFReadDirectory(TIFF* tif)
+ 				    dp->tdir_tag,dp->tdir_tag);
+ 				/* the following knowingly leaks the 
+ 				   anonymous field structure */
+-				if (!_TIFFMergeFields(tif,
+-					_TIFFCreateAnonField(tif,
+-						dp->tdir_tag,
+-						(TIFFDataType) dp->tdir_type),
+-					1)) {
++				const TIFFField *fld = _TIFFCreateAnonField(
++					tif, dp->tdir_tag, (TIFFDataType)dp->tdir_type);
++				if (fld == NULL || !_TIFFMergeFields(tif, fld, 1)) {
+ 					TIFFWarningExt(tif->tif_clientdata,
+ 					    module,
+ 					    "Registering anonymous field with tag %d (0x%x) failed",
+@@ -4425,10 +4423,9 @@ TIFFReadCustomDirectory(TIFF* tif, toff_t diroff,
+ 			TIFFWarningExt(tif->tif_clientdata, module,
+ 			    "Unknown field with tag %d (0x%x) encountered",
+ 			    dp->tdir_tag, dp->tdir_tag);
+-			if (!_TIFFMergeFields(tif, _TIFFCreateAnonField(tif,
+-						dp->tdir_tag,
+-						(TIFFDataType) dp->tdir_type),
+-					     1)) {
++			const TIFFField *fld = _TIFFCreateAnonField(
++				tif, dp->tdir_tag, (TIFFDataType)dp->tdir_type);
++			if (fld == NULL || !_TIFFMergeFields(tif, fld, 1)) {
+ 				TIFFWarningExt(tif->tif_clientdata, module,
+ 				    "Registering anonymous field with tag %d (0x%x) failed",
+ 				    dp->tdir_tag, dp->tdir_tag);
+-- 
+GitLab
+

--- a/recipes-debian/libtiff/tiff_debian.bb
+++ b/recipes-debian/libtiff/tiff_debian.bb
@@ -15,6 +15,7 @@ FILESEXTRAPATH_append = ":${COREBASE}/meta/recipes-multimedia/libtiff/files"
 
 SRC_URI += " \
            file://libtool2.patch \
+           file://CVE-2024-7006.patch \
 "
 # exclude betas
 UPSTREAM_CHECK_REGEX = "tiff-(?P<pver>\d+(\.\d+)+).tar"


### PR DESCRIPTION

# Purpose of pull request
Add patch to fix CVE-2024-7006

Backport the following commit from upstream:
- https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce881cf839fbc710f6690aadb992aa0f9e
  See: https://gitlab.com/libtiff/libtiff/-/issues/624

# Test
1. Build package
2. Check the results of cve-check
3. Run image and test the package on the qemuarm64 environment

## How to check the results of cve-check
1. Run cve-check for tiff package
2. Check the results from cve.log

### Run cve-check for tiff package
Add the following to local.conf and run cve-check.
```
INHERIT += " cve-check debian-cve-check"
```
```
$ bitbake tiff -c cve_check
```

### Check the results from cve.log
Check the CVE STATUS of CVE-2024-7006 from cve.log.
```
$ grep -A 1 ' CVE-2024-7006' ./tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/temp/cve.log
```

## How to test the package
1. Build qemuarm64 image
2. Prepare patched tiff source code
4. Run qemu image
5. Take tiff source code directory
6. Build the tiff library
7. Change the test target
8. Run tiff test

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
IMAGE_INSTALL_append = " tiff tiff-utils"
IMAGE_INSTALL_append = " openssh"
EXTRA_IMAGE_FEATURES_append = " tools-sdk"
```
```
$ bitbake core-image-minimal
```

### Prepare patched tiff source code
```
$ bitbake -c cleanall tiff
$ bitbake tiff -c patch
```


### Run qemu image
```
$ runqemu qemuarm64 nographic
```

### Take tiff source code directory
Take the tiff source code directory (build/tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/tiff-4.1.0+git191117) to the running qemu environment using scp.
```
# scp -r <USERNAME>@<HOST>:<DIR>/build/tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/tiff-4.1.0+git191117 .
```

### Build the tiff library
Build the tiff library required to build the test tools.
```
# cd tiff-4.1.0+git191117/
# ./autogen.sh 
# ./configure 
# make -C port
# make -C libtiff
```

### Change the test target
Modify the test common file(./test/common.sh) as follows.

Modify the TOOLS path to use the executable files installed by tiff-utils.
./test/common.sh diff:
```diff
@@ -5,7 +5,7 @@ BUILDDIR=`pwd`
 SRCDIR=`dirname $0`
 SRCDIR=`cd $SRCDIR && pwd`
 TOPSRCDIR=`cd $srcdir/.. && pwd`
-TOOLS=`cd ../tools && pwd`
+TOOLS="/usr/bin"
 IMAGES="${SRCDIR}/images"
 REFS="${SRCDIR}/refs"
```

### Run tiff test
```
# make -C test check-TESTS
```

## Test result
### Build package
Build succeeded.
```
$ bitbake tiff
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2382 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:ed4ace81663b05209a94a7f99815a0d600276588"
meta-debian-extended = "tiff-add-CVE-2024-7006-patch:64b8c1117513bfe6235ac126b1b4a477d5ffece9"
meta-emlinux         = "HEAD:5944caff09396a9f1bd10897e86f4c839b740ac3"
meta-emlinux-private = "HEAD:3534c7782ba150055729db6720e5c10264c2d0e7"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 6 Found 0 Missed 6 Current 438 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2047 tasks of which 2036 didn't need to be rerun and all succeeded.
```

### Check the results of cve-check
The result of cve-check was that the "CVE STATUS" for CVE-2024-7006 was "Patched".
```
$ bitbake tiff -c cve_check
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2382 entries from dependency cache.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:00
Parsing of 1360 .bb files complete (1359 cached, 1 parsed). 2382 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:ed4ace81663b05209a94a7f99815a0d600276588"
meta-debian-extended = "tiff-add-CVE-2024-7006-patch:64b8c1117513bfe6235ac126b1b4a477d5ffece9"
meta-emlinux         = "HEAD:5944caff09396a9f1bd10897e86f4c839b740ac3"
meta-emlinux-private = "HEAD:3534c7782ba150055729db6720e5c10264c2d0e7"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: tiff-4.1.0+git191117-r0 do_cve_check: Found unpatched CVE (CVE-2020-35521 CVE-2020-35522 CVE-2022-2953 CVE-2022-40090 CVE-2023-1916 CVE-2023-3164 CVE-2023-52355 CVE-2023-6228 CVE-2023-6277), for more information check /work2/EMLinux2.x/test2/build/tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```
```
$ grep -A 1 ' CVE-2024-7006' ./tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/temp/cve.log
CVE: CVE-2024-7006
CVE STATUS: Patched
```

For reference, before this PR it was "Unpatched".
```
build$ grep -A 1 ' CVE-2024-7006' ./tmp-glibc/work/aarch64-emlinux-linux/tiff/4.1.0+git191117-r0/temp/cve.log
CVE: CVE-2024-7006
CVE STATUS: Unpatched
```

### Package test
Tests pass, except for 'thumbnail' which is not included in tiff-utils package.
```
root@qemuarm64:~/tiff-4.1.0+git191117# make -C test check-TESTS
make: Entering directory '/home/root/tiff-4.1.0+git191117/test'
...
make[1]: Entering directory '/home/root/tiff-4.1.0+git191117/test'
PASS: ascii_tag
PASS: long_tag
PASS: short_tag
PASS: strip_rw
PASS: rewrite
PASS: custom_dir
PASS: defer_strile_loading
PASS: defer_strile_writing
PASS: testtypes
PASS: ppm2tiff_pbm.sh
PASS: ppm2tiff_pgm.sh
PASS: ppm2tiff_ppm.sh
PASS: fax2tiff.sh
PASS: tiffcp-g3.sh
PASS: tiffcp-g3-1d.sh
PASS: tiffcp-g3-1d-fill.sh
PASS: tiffcp-g3-2d.sh
PASS: tiffcp-g3-2d-fill.sh
PASS: tiffcp-g4.sh
PASS: tiffcp-logluv.sh
FAIL: tiffcp-thumbnail.sh
PASS: tiffcp-lzw-compat.sh
PASS: tiffcp-lzw-scanline-decode.sh
PASS: tiffdump.sh
PASS: tiffinfo.sh
PASS: tiffcp-split.sh
PASS: tiffcp-split-join.sh
PASS: tiff2ps-PS1.sh
PASS: tiff2ps-PS2.sh
PASS: tiff2ps-PS3.sh
PASS: tiff2ps-EPS1.sh
PASS: tiff2pdf.sh
PASS: tiffcrop-doubleflip-logluv-3c-16b.sh
PASS: tiffcrop-doubleflip-minisblack-1c-16b.sh
PASS: tiffcrop-doubleflip-minisblack-1c-8b.sh
PASS: tiffcrop-doubleflip-minisblack-2c-8b-alpha.sh
PASS: tiffcrop-doubleflip-miniswhite-1c-1b.sh
PASS: tiffcrop-doubleflip-palette-1c-1b.sh
PASS: tiffcrop-doubleflip-palette-1c-4b.sh
PASS: tiffcrop-doubleflip-palette-1c-8b.sh
PASS: tiffcrop-doubleflip-rgb-3c-16b.sh
PASS: tiffcrop-doubleflip-rgb-3c-8b.sh
PASS: tiffcrop-extract-logluv-3c-16b.sh
PASS: tiffcrop-extract-minisblack-1c-16b.sh
PASS: tiffcrop-extract-minisblack-1c-8b.sh
PASS: tiffcrop-extract-minisblack-2c-8b-alpha.sh
PASS: tiffcrop-extract-miniswhite-1c-1b.sh
PASS: tiffcrop-extract-palette-1c-1b.sh
PASS: tiffcrop-extract-palette-1c-4b.sh
PASS: tiffcrop-extract-palette-1c-8b.sh
PASS: tiffcrop-extract-rgb-3c-16b.sh
PASS: tiffcrop-extract-rgb-3c-8b.sh
PASS: tiffcrop-extractz14-logluv-3c-16b.sh
PASS: tiffcrop-extractz14-minisblack-1c-16b.sh
PASS: tiffcrop-extractz14-minisblack-1c-8b.sh
PASS: tiffcrop-extractz14-minisblack-2c-8b-alpha.sh
PASS: tiffcrop-extractz14-miniswhite-1c-1b.sh
PASS: tiffcrop-extractz14-palette-1c-1b.sh
PASS: tiffcrop-extractz14-palette-1c-4b.sh
PASS: tiffcrop-extractz14-palette-1c-8b.sh
PASS: tiffcrop-extractz14-rgb-3c-16b.sh
PASS: tiffcrop-extractz14-rgb-3c-8b.sh
PASS: tiffcrop-R90-logluv-3c-16b.sh
PASS: tiffcrop-R90-minisblack-1c-16b.sh
PASS: tiffcrop-R90-minisblack-1c-8b.sh
PASS: tiffcrop-R90-minisblack-2c-8b-alpha.sh
PASS: tiffcrop-R90-miniswhite-1c-1b.sh
PASS: tiffcrop-R90-palette-1c-1b.sh
PASS: tiffcrop-R90-palette-1c-4b.sh
PASS: tiffcrop-R90-palette-1c-8b.sh
PASS: tiffcrop-R90-rgb-3c-16b.sh
PASS: tiffcrop-R90-rgb-3c-8b.sh
PASS: tiff2bw-palette-1c-8b.sh
PASS: tiff2bw-quad-lzw-compat.sh
PASS: tiff2bw-rgb-3c-8b.sh
PASS: tiff2rgba-logluv-3c-16b.sh
PASS: tiff2rgba-minisblack-1c-16b.sh
PASS: tiff2rgba-minisblack-1c-8b.sh
PASS: tiff2rgba-minisblack-2c-8b-alpha.sh
PASS: tiff2rgba-miniswhite-1c-1b.sh
PASS: tiff2rgba-palette-1c-1b.sh
PASS: tiff2rgba-palette-1c-4b.sh
PASS: tiff2rgba-palette-1c-8b.sh
PASS: tiff2rgba-rgb-3c-16b.sh
PASS: tiff2rgba-rgb-3c-8b.sh
============================================================================
Testsuite summary for LibTIFF Software 4.1.0
============================================================================
# TOTAL: 85
# PASS:  84
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See test/test-suite.log
Please report to tiff@lists.maptools.org
============================================================================
make[1]: *** [Makefile:1039: test-suite.log] Error 1
make[1]: Leaving directory '/home/root/tiff-4.1.0+git191117/test'
make: *** [Makefile:1147: check-TESTS] Error 2
make: Leaving directory '/home/root/tiff-4.1.0+git191117/test'
```