### PR TITLE
cluster-glue: Set CVE_PRODUCT for cve_check

### DIFF
--- a/recipes-debian/cluster-glue/cluster-glue_debian.bb
+++ b/recipes-debian/cluster-glue/cluster-glue_debian.bb
@@ -17,6 +17,8 @@ DEPENDS = "libxml2 libtool glib-2.0 bzip2 util-linux net-snmp openhpi libopenipm
 inherit debian-package
 require recipes-debian/sources/cluster-glue.inc
 
+CVE_PRODUCT = "clusterlabs:cluster_glue"
+
 SRC_URI += " \
     file://0001-don-t-compile-doc-and-Error-Fix.patch \
     file://0001-ribcl.py.in-Warning-Fix.patch \


### PR DESCRIPTION
# Purpose of pull request

The default "cluster-glue" had been set for CVE_PRODUCT, but in the NVD registration, it is set to "cluster_glue" (underbar), so this should be corrected.
To prevent false positives, also set the vendor.
[CVE-2010-2496](https://nvd.nist.gov/vuln/detail/CVE-2010-2496) was used as a reference when checking with NVD.

# Test
## How to test

Confirm that CVE_PRODUCT in cluster-glue package has been set.
After that, run cve_check on cluster-glue package to confirm that there are no errors.

1. Set local.conf 
   Set the following MACHINE and INHERIT settings in local.conf.

   ```
   MACHINE = "qemuarm64"
   INHERIT += "cve-check debian-cve-check kernel-cve-check"
   ```

2. Check value of CVE_PRODUCT
   Run following command to check the value of CVE_PRODUCT of cluster-glue.

   ```
   $ bitbake cluster-glue -c cve_check -e | grep -e '^CVE_PRODUCT='
   ```

3. Run cve_check
   Run following command to perform a cve_check of cluster-glue.

   ```
   $ bitbake cluster-glue -c cve_check
   ```

4. Check cve.log
   Run following command to check the generated cve.log.

   ```
   $ cat tmp-glibc/work/aarch64-emlinux-linux/cluster-glue/1.0.12-r0/temp/cve.log
   ```

## Test result

### Check the value of CVE_PRODUCT

Before this patch

```
$ bitbake cluster-glue -c cve_check -e | grep -e '^CVE_PRODUCT='
CVE_PRODUCT="cluster-glue"
```

After this patch

```
$ bitbake cluster-glue -c cve_check -e | grep -e '^CVE_PRODUCT='
CVE_PRODUCT="clusterlabs:cluster_glue"
```

### Ran cve_check

Ran cve_check against cluster-glue and verified that no errors occurred.

```
$ bitbake cluster-glue -c cve_check
Loading cache: 100% |#################################################################################################| Time: 0:00:00
Loaded 2381 entries from dependency cache.
Parsing recipes: 100% |###############################################################################################| Time: 0:00:00
Parsing of 1359 .bb files complete (1357 cached, 2 parsed). 2381 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:14a35eb170b7cbd02f51f3de298c99ca347bdfa5"
meta-debian-extended = "set-cve_product-for-cve-check:1f08e9e6b6421d532678a0ad76566256bcfad5a0"
meta-emlinux         = "HEAD:a82a13b9725b32e9b920913e4ae306f967d5fc5b"
meta-emlinux-private = "HEAD:3534c7782ba150055729db6720e5c10264c2d0e7"

Initialising tasks: 100% |############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```

### Check cve.log

Confirmed that cve.log was not generated before the patch, but it is generated after applying the patch.

Before this patch

No cve.log was generated.

```
$ cat tmp-glibc/work/aarch64-emlinux-linux/cluster-glue/1.0.12-r0/temp/cve.log
cat: tmp-glibc/work/aarch64-emlinux-linux/cluster-glue/1.0.12-r0/temp/cve.log: No such file or directory
```

After this patch

cve.log was generated with the following contents.

```
$ cat tmp-glibc/work/aarch64-emlinux-linux/cluster-glue/1.0.12-r0/temp/cve.log
PACKAGE NAME: cluster-glue
PACKAGE VERSION: 1.0.12
CVE: CVE-2010-2496
CVE STATUS: Patched
CVE SUMMARY: stonith-ng in pacemaker and cluster-glue passed passwords as commandline parameters, making it possible for local attackers to gain access to passwords of the HA stack and potentially influence its operations. This is fixed in cluster-glue 1.0.6 and newer, and pacemaker 1.1.3 and newer.
CVSS v2 BASE SCORE: 2.1
CVSS v3 BASE SCORE: 5.5
VECTOR: LOCAL
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2010-2496

```