### PR TITLE
ruby-ptest: Modify run-ptest from Poky based to use debian/tests/run-all

### DIFF
--- a/recipes-debian/ruby/ruby/add-test-preparation-and-fix-result-output.patch
+++ b/recipes-debian/ruby/ruby/add-test-preparation-and-fix-result-output.patch
@@ -1,0 +1,59 @@
+From c44836ad453f713d5c4786ddaae10baea3f2bc8d Mon Sep 17 00:00:00 2001
+From: Takahiro Terada <takahiro.terada@miraclelinux.com>
+Date: Thu, 12 Dec 2024 10:39:11 +0000
+Subject: [PATCH] debian/tests/run-all: Add test preparation and fix result
+ output
+
+- Add test preparation
+  - for test/erb/test_erb_command.rb
+    In the recipe, installed symbolic link to /usr/bin/erb in ptest/bin/erb, and
+    add step to copy the bin directory to test working directory.
+
+- Fix result output to Automake format
+  The Poky documentation states that the ptest result is Automake.[1]
+
+  [1] https://wiki.yoctoproject.org/wiki/Ptest#What_constitutes_a_ptest?
+
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+---
+ debian/tests/run-all | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/debian/tests/run-all b/debian/tests/run-all
+index 2e9aadd..d804c7f 100755
+--- a/debian/tests/run-all
++++ b/debian/tests/run-all
+@@ -21,6 +21,7 @@ fi
+ 
+ excludedir=$(readlink -f $(dirname $0))/excludes
+ cp -r 'test/' $ADTTMP
++cp -r 'bin/' $ADTTMP
+ cd $ADTTMP
+ 
+ if [ -z "$tests" ]; then
+@@ -40,17 +41,17 @@ excludes="$excludes --excludes-dir=${excludedir}/$(dpkg-architecture -qDEB_HOST_
+ 
+ for t in $tests; do
+   if ruby2.5 test/runner.rb -v $excludes --name='!/memory_leak/' $t >log 2>&1; then
+-    echo "PASS $t"
++    echo "PASS: $t"
+     pass=$(($pass + 1))
+   else
+     if grep "^$t$" $KNOW_FAILURES; then
+       fail_expected=$(($fail_expected + 1))
+-      echo "FAIL (EXPECTED) $t"
+-      echo "FAIL (EXPECTED) $t" | sed -e 's/./-/g'
++      echo "FAIL: (EXPECTED) $t"
++      echo "FAIL: (EXPECTED) $t" | sed -e 's/./-/g'
+     else
+       fail=$(($fail + 1))
+-      echo "FAIL $t"
+-      echo "FAIL $t" | sed -e 's/./-/g'
++      echo "FAIL: $t"
++      echo "FAIL: $t" | sed -e 's/./-/g'
+     fi
+     echo
+     cat log
+-- 
+2.25.1
+

--- a/recipes-debian/ruby/ruby/fix-for-tzdata-2022g.patch
+++ b/recipes-debian/ruby/ruby/fix-for-tzdata-2022g.patch
@@ -1,0 +1,74 @@
+From 58cc3c9f387dcf8f820b43e043b540fa06248da3 Mon Sep 17 00:00:00 2001
+From: Nobuyoshi Nakada <nobu@ruby-lang.org>
+Date: Wed, 7 Dec 2022 13:08:40 +0900
+Subject: [Bug #19187] Fix for tzdata-2022g
+
+---
+ test/ruby/test_time_tz.rb | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+(limited to 'test/ruby/test_time_tz.rb')
+
+Upstream-Status: Backport [https://git.ruby-lang.org/ruby.git/patch/test/ruby/test_time_tz.rb?id=58cc3c9f387dcf8f820b43e043b540fa06248da3]
+Comments: Refreshed Hunk
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+
+
+diff --git a/test/ruby/test_time_tz.rb b/test/ruby/test_time_tz.rb
+index 6fdb95bafe..6e7e813923 100644
+--- a/test/ruby/test_time_tz.rb
++++ b/test/ruby/test_time_tz.rb
+@@ -6,9 +6,9 @@ class TestTimeTZ < Test::Unit::TestCase
+   has_lisbon_tz = true
+   force_tz_test = ENV["RUBY_FORCE_TIME_TZ_TEST"] == "yes"
+   case RUBY_PLATFORM
+-  when /linux/
++  when /darwin|linux/
+     force_tz_test = true
+-  when /darwin|freebsd/
++  when /freebsd|openbsd/
+     has_lisbon_tz = false
+     force_tz_test = true
+   end
+@@ -94,6 +94,9 @@ def group_by(e, &block)
+   CORRECT_KIRITIMATI_SKIP_1994 = with_tz("Pacific/Kiritimati") {
+     Time.local(1994, 12, 31, 0, 0, 0).year == 1995
+   }
++  CORRECT_SINGAPORE_1982 = with_tz("Asia/Singapore") {
++    "2022g" if Time.local(1981, 12, 31, 23, 59, 59).utc_offset == 8*3600
++  }
+ 
+   def time_to_s(t)
+     t.to_s
+@@ -139,9 +142,12 @@ def test_america_managua
+ 
+   def test_asia_singapore
+     with_tz(tz="Asia/Singapore") {
+-      assert_time_constructor(tz, "1981-12-31 23:59:59 +0730", :local, [1981,12,31,23,59,59])
+-      assert_time_constructor(tz, "1982-01-01 00:30:00 +0800", :local, [1982,1,1,0,0,0])
+-      assert_time_constructor(tz, "1982-01-01 00:59:59 +0800", :local, [1982,1,1,0,29,59])
++      assert_time_constructor(tz, "1981-12-31 23:29:59 +0730", :local, [1981,12,31,23,29,59])
++      if CORRECT_SINGAPORE_1982
++        assert_time_constructor(tz, "1982-01-01 00:00:00 +0800", :local, [1981,12,31,23,30,00])
++        assert_time_constructor(tz, "1982-01-01 00:00:00 +0800", :local, [1982,1,1,0,0,0])
++        assert_time_constructor(tz, "1982-01-01 00:29:59 +0800", :local, [1982,1,1,0,29,59])
++      end
+       assert_time_constructor(tz, "1982-01-01 00:30:00 +0800", :local, [1982,1,1,0,30,0])
+     }
+   end
+@@ -358,8 +364,11 @@ def self.gen_zdump_test(data)
+ America/Managua  Wed Jan  1 04:59:59 1997 UTC = Tue Dec 31 23:59:59 1996 EST isdst=0 gmtoff=-18000
+ America/Managua  Wed Jan  1 05:00:00 1997 UTC = Tue Dec 31 23:00:00 1996 CST isdst=0 gmtoff=-21600
+ Asia/Singapore  Sun Aug  8 16:30:00 1965 UTC = Mon Aug  9 00:00:00 1965 SGT isdst=0 gmtoff=27000
+-Asia/Singapore  Thu Dec 31 16:29:59 1981 UTC = Thu Dec 31 23:59:59 1981 SGT isdst=0 gmtoff=27000
++Asia/Singapore  Thu Dec 31 15:59:59 1981 UTC = Thu Dec 31 23:29:59 1981 SGT isdst=0 gmtoff=27000
+ Asia/Singapore  Thu Dec 31 16:30:00 1981 UTC = Fri Jan  1 00:30:00 1982 SGT isdst=0 gmtoff=28800
++End
++  gen_zdump_test <<'End' if CORRECT_SINGAPORE_1982
++Asia/Singapore  Thu Dec 31 16:00:00 1981 UTC = Fri Jan  1 00:00:00 1982 SGT isdst=0 gmtoff=28800
+ End
+   gen_zdump_test CORRECT_TOKYO_DST_1951 ? <<'End' + (CORRECT_TOKYO_DST_1951 < "2018f" ? <<'2018e' : <<'2018f') : <<'End'
+ Asia/Tokyo  Sat May  5 14:59:59 1951 UTC = Sat May  5 23:59:59 1951 JST isdst=0 gmtoff=32400
+-- 
+cgit v1.2.3
+

--- a/recipes-debian/ruby/ruby/renew-test-certificates.patch
+++ b/recipes-debian/ruby/ruby/renew-test-certificates.patch
@@ -1,0 +1,246 @@
+From d3933fc753187a055a4904af82f5f3794c88c416 Mon Sep 17 00:00:00 2001
+From: Sorah Fukumori <her@sorah.jp>
+Date: Mon, 1 Jan 2024 20:45:54 +0900
+Subject: [ruby/net-http] Renew test certificates
+
+The private key is replaced with a public known test key published at
+[RFC 9500].
+
+Also lifetime has been extended to 10 years from 4 years.
+
+[RFC 9500]: https://www.rfc-editor.org/rfc/rfc9500.html
+
+https://github.com/ruby/net-http/commit/4ab6c4a500
+---
+ test/net/fixtures/cacert.pem | 44 ++++++++++----------
+ test/net/fixtures/server.crt | 99 +++++++++-----------------------------------
+ test/net/fixtures/server.key | 55 ++++++++++++------------
+ 4 files changed, 71 insertions(+), 133 deletions(-)
+
+(limited to 'test/net/fixtures')
+
+Upstream-Status: Backport [https://git.ruby-lang.org/ruby.git/patch/test/net/fixtures?id=d3933fc753187a055a4904af82f5f3794c88c416a]
+Comments: Excluded test/net/fixtures/Makefile and Refreshed Hunk
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+
+
+diff --git a/test/net/fixtures/cacert.pem b/test/net/fixtures/cacert.pem
+index f623bd62ed..24c83f1c65 100644
+--- a/test/net/fixtures/cacert.pem
++++ b/test/net/fixtures/cacert.pem
+@@ -1,24 +1,24 @@
+ -----BEGIN CERTIFICATE-----
+-MIID7TCCAtWgAwIBAgIJAIltvxrFAuSnMA0GCSqGSIb3DQEBCwUAMIGMMQswCQYD
+-VQQGEwJKUDEQMA4GA1UECAwHU2hpbWFuZTEUMBIGA1UEBwwLTWF0ei1lIGNpdHkx
+-FzAVBgNVBAoMDlJ1YnkgQ29yZSBUZWFtMRUwEwYDVQQDDAxSdWJ5IFRlc3QgQ0Ex
+-JTAjBgkqhkiG9w0BCQEWFnNlY3VyaXR5QHJ1YnktbGFuZy5vcmcwHhcNMTkwMTAy
+-MDI1ODI4WhcNMjQwMTAxMDI1ODI4WjCBjDELMAkGA1UEBhMCSlAxEDAOBgNVBAgM
+-B1NoaW1hbmUxFDASBgNVBAcMC01hdHotZSBjaXR5MRcwFQYDVQQKDA5SdWJ5IENv
+-cmUgVGVhbTEVMBMGA1UEAwwMUnVieSBUZXN0IENBMSUwIwYJKoZIhvcNAQkBFhZz
+-ZWN1cml0eUBydWJ5LWxhbmcub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+-CgKCAQEAznlbjRVhz1NlutHVrhcGnK8W0qug2ujKXv1njSC4U6nJF6py7I9EeehV
+-SaKePyv+I9z3K1LnfUHOtUbdwdKC77yN66A6q2aqzu5q09/NSykcZGOIF0GuItYI
+-3nvW3IqBddff2ffsyR+9pBjfb5AIPP08WowF9q4s1eGULwZc4w2B8PFhtxYANd7d
+-BvGLXFlcufv9tDtzyRi4t7eqxCRJkZQIZNZ6DHHIJrNxejOILfHLarI12yk8VK6L
+-2LG4WgGqyeePiRyd1o1MbuiAFYqAwpXNUbRKg5NaZGwBHZk8UZ+uFKt1QMBURO5R
+-WFy1c349jbWszTqFyL4Lnbg9HhAowQIDAQABo1AwTjAdBgNVHQ4EFgQU9tEiKdU9
+-I9derQyc5nWPnc34nVMwHwYDVR0jBBgwFoAU9tEiKdU9I9derQyc5nWPnc34nVMw
+-DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAxj7F/u3C3fgq24N7hGRA
+-of7ClFQxGmo/IGT0AISzW3HiVYiFaikKhbO1NwD9aBpD8Zwe62sCqMh8jGV/b0+q
+-aOORnWYNy2R6r9FkASAglmdF6xn3bhgGD5ls4pCvcG9FynGnGc24g6MrjFNrBYUS
+-2iIZsg36i0IJswo/Dy6HLphCms2BMCD3DeWtfjePUiTmQHJo6HsQIKP/u4N4Fvee
+-uMBInei2M4VU74fLXbmKl1F9AEX7JDP3BKSZG19Ch5pnUo4uXM1uNTGsi07P4Y0s
+-K44+SKBC0bYEFbDK0eQWMrX3kIhkPxyIWhxdq9/NqPYjShuSEAhA6CSpmRg0pqc+
+-mA==
++MIID+zCCAuOgAwIBAgIUGMvHl3EhtKPKcgc3NQSAYfFuC+8wDQYJKoZIhvcNAQEL
++BQAwgYwxCzAJBgNVBAYTAkpQMRAwDgYDVQQIDAdTaGltYW5lMRQwEgYDVQQHDAtN
++YXR6LWUgY2l0eTEXMBUGA1UECgwOUnVieSBDb3JlIFRlYW0xFTATBgNVBAMMDFJ1
++YnkgVGVzdCBDQTElMCMGCSqGSIb3DQEJARYWc2VjdXJpdHlAcnVieS1sYW5nLm9y
++ZzAeFw0yNDAxMDExMTQ3MjNaFw0zMzEyMjkxMTQ3MjNaMIGMMQswCQYDVQQGEwJK
++UDEQMA4GA1UECAwHU2hpbWFuZTEUMBIGA1UEBwwLTWF0ei1lIGNpdHkxFzAVBgNV
++BAoMDlJ1YnkgQ29yZSBUZWFtMRUwEwYDVQQDDAxSdWJ5IFRlc3QgQ0ExJTAjBgkq
++hkiG9w0BCQEWFnNlY3VyaXR5QHJ1YnktbGFuZy5vcmcwggEiMA0GCSqGSIb3DQEB
++AQUAA4IBDwAwggEKAoIBAQCw+egZQ6eumJKq3hfKfED4dE/tL4FI5sjqont9ABVI
+++1GSqyi1bFBgsRjM0THllIdMbKmJtWwnKW8J+5OgNN8y6Xxv8JmM/Y5vQt2lis0f
++qXmG8UTz0VTWdlAXXmhUs6lSADvAaIe4RVrCsZ97L3ZQTryY7JRVcbB4khUN3Gp0
++yg+801SXzoFTTa+UGIRLE66jH51aa5VXu99hnv1OiH8tQrjdi8mH6uG/icq4XuIe
++NWMF32wHqIOOPvQcWV3M5D2vxJEj702Ku6k9OQXkAo17qRSEonWW4HtLbtmS8He1
++JNPc/n3dVUm+fM6NoDXPoLP7j55G9zKyqGtGAWXAj1MTAgMBAAGjUzBRMB0GA1Ud
++DgQWBBSJGVleDvFp9cu9R+E0/OKYzGkwkTAfBgNVHSMEGDAWgBSJGVleDvFp9cu9
++R+E0/OKYzGkwkTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBl
++8GLB8skAWlkSw/FwbUmEV3zyqu+p7PNP5YIYoZs0D74e7yVulGQ6PKMZH5hrZmHo
++orFSQU+VUUirG8nDGj7Rzce8WeWBxsaDGC8CE2dq6nC6LuUwtbdMnBrH0LRWAz48
++jGFF3jHtVz8VsGfoZTZCjukWqNXvU6hETT9GsfU+PZqbqcTVRPH52+XgYayKdIbD
++r97RM4X3+aXBHcUW0b76eyyi65RR/Xtvn8ioZt2AdX7T2tZzJyXJN3Hupp77s6Ui
++AZR35SToHCZeTZD12YBvLBdaTPLZN7O/Q/aAO9ZiJaZ7SbFOjz813B2hxXab4Fob
++2uJX6eMWTVxYK5D4M9lm
+ -----END CERTIFICATE-----
+diff --git a/test/net/fixtures/server.crt b/test/net/fixtures/server.crt
+index 5ca78a6d14..5d2923795d 100644
+--- a/test/net/fixtures/server.crt
++++ b/test/net/fixtures/server.crt
+@@ -1,82 +1,21 @@
+-Certificate:
+-    Data:
+-        Version: 3 (0x2)
+-        Serial Number: 2 (0x2)
+-    Signature Algorithm: sha256WithRSAEncryption
+-        Issuer: C=JP, ST=Shimane, L=Matz-e city, O=Ruby Core Team, CN=Ruby Test CA/emailAddress=security@ruby-lang.org
+-        Validity
+-            Not Before: Jan  2 03:27:13 2019 GMT
+-            Not After : Jan  1 03:27:13 2024 GMT
+-        Subject: C=JP, ST=Shimane, O=Ruby Core Team, OU=Ruby Test, CN=localhost
+-        Subject Public Key Info:
+-            Public Key Algorithm: rsaEncryption
+-                Public-Key: (2048 bit)
+-                Modulus:
+-                    00:e8:da:9c:01:2e:2b:10:ec:49:cd:5e:07:13:07:
+-                    9c:70:9e:c6:74:bc:13:c2:e1:6f:c6:82:fd:e3:48:
+-                    e0:2c:a5:68:c7:9e:42:de:60:54:65:e6:6a:14:57:
+-                    7a:30:d0:cc:b5:b6:d9:c3:d2:df:c9:25:97:54:67:
+-                    cf:f6:be:5e:cb:8b:ee:03:c5:e1:e2:f9:e7:f7:d1:
+-                    0c:47:f0:b8:da:33:5a:ad:41:ad:e7:b5:a2:7b:b7:
+-                    bf:30:da:60:f8:e3:54:a2:bc:3a:fd:1b:74:d9:dc:
+-                    74:42:e9:29:be:df:ac:b4:4f:eb:32:f4:06:f1:e1:
+-                    8c:4b:a8:8b:fb:29:e7:b1:bf:1d:01:ee:73:0f:f9:
+-                    40:dc:d5:15:79:d9:c6:73:d0:c0:dd:cb:e4:da:19:
+-                    47:80:c6:14:04:72:fd:9a:7c:8f:11:82:76:49:04:
+-                    79:cc:f2:5c:31:22:95:13:3e:5d:40:a6:4d:e0:a3:
+-                    02:26:7d:52:3b:bb:ed:65:a1:0f:ed:6b:b0:3c:d4:
+-                    de:61:15:5e:d3:dd:68:09:9f:4a:57:a5:c2:a9:6d:
+-                    86:92:c5:f4:a4:d4:b7:13:3b:52:63:24:05:e2:cc:
+-                    e3:8a:3c:d4:35:34:2b:10:bb:58:72:e7:e1:8d:1d:
+-                    74:8c:61:16:20:3d:d0:1c:4e:8f:6e:fd:fe:64:10:
+-                    4f:41
+-                Exponent: 65537 (0x10001)
+-        X509v3 extensions:
+-            X509v3 Basic Constraints: 
+-                CA:FALSE
+-            Netscape Comment: 
+-                OpenSSL Generated Certificate
+-            X509v3 Subject Key Identifier: 
+-                ED:28:C2:7E:AB:4B:C8:E8:FE:55:6D:66:95:31:1C:2D:60:F9:02:36
+-            X509v3 Authority Key Identifier: 
+-                keyid:F6:D1:22:29:D5:3D:23:D7:5E:AD:0C:9C:E6:75:8F:9D:CD:F8:9D:53
+-
+-    Signature Algorithm: sha256WithRSAEncryption
+-         1d:b8:c5:8b:72:41:20:65:ad:27:6f:15:63:06:26:12:8d:9c:
+-         ad:ca:f4:db:97:b4:90:cb:ff:35:94:bb:2a:a7:a1:ab:1e:35:
+-         2d:a5:3f:c9:24:b0:1a:58:89:75:3e:81:0a:2c:4f:98:f9:51:
+-         fb:c0:a3:09:d0:0a:9b:e7:a2:b7:c3:60:40:c8:f4:6d:b2:6a:
+-         56:12:17:4c:00:24:31:df:9c:60:ae:b1:68:54:a9:e6:b5:4a:
+-         04:e6:92:05:86:d9:5a:dc:96:30:a5:58:de:14:99:0f:e5:15:
+-         89:3e:9b:eb:80:e3:bd:83:c3:ea:33:35:4b:3e:2f:d3:0d:64:
+-         93:67:7f:8d:f5:3f:0c:27:bc:37:5a:cc:d6:47:16:af:5a:62:
+-         d2:da:51:f8:74:06:6b:24:ad:28:68:08:98:37:7d:ed:0e:ab:
+-         1e:82:61:05:d0:ba:75:a0:ab:21:b0:9a:fd:2b:54:86:1d:0d:
+-         1f:c2:d4:77:1f:72:26:5e:ad:8a:9f:09:36:6d:44:be:74:c2:
+-         5a:3e:ff:5c:9d:75:d6:38:7b:c5:39:f9:44:6e:a1:d1:8e:ff:
+-         63:db:c4:bb:c6:91:92:ca:5c:60:9b:1d:eb:0a:de:08:ee:bf:
+-         da:76:03:65:62:29:8b:f8:7f:c7:86:73:1e:f6:1f:2d:89:69:
+-         fd:be:bd:6e
+ -----BEGIN CERTIFICATE-----
+-MIID4zCCAsugAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBjDELMAkGA1UEBhMCSlAx
+-EDAOBgNVBAgMB1NoaW1hbmUxFDASBgNVBAcMC01hdHotZSBjaXR5MRcwFQYDVQQK
+-DA5SdWJ5IENvcmUgVGVhbTEVMBMGA1UEAwwMUnVieSBUZXN0IENBMSUwIwYJKoZI
+-hvcNAQkBFhZzZWN1cml0eUBydWJ5LWxhbmcub3JnMB4XDTE5MDEwMjAzMjcxM1oX
+-DTI0MDEwMTAzMjcxM1owYDELMAkGA1UEBhMCSlAxEDAOBgNVBAgMB1NoaW1hbmUx
+-FzAVBgNVBAoMDlJ1YnkgQ29yZSBUZWFtMRIwEAYDVQQLDAlSdWJ5IFRlc3QxEjAQ
+-BgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+-AOjanAEuKxDsSc1eBxMHnHCexnS8E8Lhb8aC/eNI4CylaMeeQt5gVGXmahRXejDQ
+-zLW22cPS38kll1Rnz/a+XsuL7gPF4eL55/fRDEfwuNozWq1Bree1onu3vzDaYPjj
+-VKK8Ov0bdNncdELpKb7frLRP6zL0BvHhjEuoi/sp57G/HQHucw/5QNzVFXnZxnPQ
+-wN3L5NoZR4DGFARy/Zp8jxGCdkkEeczyXDEilRM+XUCmTeCjAiZ9Uju77WWhD+1r
+-sDzU3mEVXtPdaAmfSlelwqlthpLF9KTUtxM7UmMkBeLM44o81DU0KxC7WHLn4Y0d
+-dIxhFiA90BxOj279/mQQT0ECAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhC
+-AQ0EHxYdT3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFO0o
+-wn6rS8jo/lVtZpUxHC1g+QI2MB8GA1UdIwQYMBaAFPbRIinVPSPXXq0MnOZ1j53N
+-+J1TMA0GCSqGSIb3DQEBCwUAA4IBAQAduMWLckEgZa0nbxVjBiYSjZytyvTbl7SQ
+-y/81lLsqp6GrHjUtpT/JJLAaWIl1PoEKLE+Y+VH7wKMJ0Aqb56K3w2BAyPRtsmpW
+-EhdMACQx35xgrrFoVKnmtUoE5pIFhtla3JYwpVjeFJkP5RWJPpvrgOO9g8PqMzVL
+-Pi/TDWSTZ3+N9T8MJ7w3WszWRxavWmLS2lH4dAZrJK0oaAiYN33tDqsegmEF0Lp1
+-oKshsJr9K1SGHQ0fwtR3H3ImXq2Knwk2bUS+dMJaPv9cnXXWOHvFOflEbqHRjv9j
+-28S7xpGSylxgmx3rCt4I7r/adgNlYimL+H/HhnMe9h8tiWn9vr1u
++MIIDYTCCAkkCAQAwDQYJKoZIhvcNAQELBQAwgYwxCzAJBgNVBAYTAkpQMRAwDgYD
++VQQIDAdTaGltYW5lMRQwEgYDVQQHDAtNYXR6LWUgY2l0eTEXMBUGA1UECgwOUnVi
++eSBDb3JlIFRlYW0xFTATBgNVBAMMDFJ1YnkgVGVzdCBDQTElMCMGCSqGSIb3DQEJ
++ARYWc2VjdXJpdHlAcnVieS1sYW5nLm9yZzAeFw0yNDAxMDExMTQ3MjNaFw0zMzEy
++MjkxMTQ3MjNaMGAxCzAJBgNVBAYTAkpQMRAwDgYDVQQIDAdTaGltYW5lMRcwFQYD
++VQQKDA5SdWJ5IENvcmUgVGVhbTESMBAGA1UECwwJUnVieSBUZXN0MRIwEAYDVQQD
++DAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw+egZ
++Q6eumJKq3hfKfED4dE/tL4FI5sjqont9ABVI+1GSqyi1bFBgsRjM0THllIdMbKmJ
++tWwnKW8J+5OgNN8y6Xxv8JmM/Y5vQt2lis0fqXmG8UTz0VTWdlAXXmhUs6lSADvA
++aIe4RVrCsZ97L3ZQTryY7JRVcbB4khUN3Gp0yg+801SXzoFTTa+UGIRLE66jH51a
++a5VXu99hnv1OiH8tQrjdi8mH6uG/icq4XuIeNWMF32wHqIOOPvQcWV3M5D2vxJEj
++702Ku6k9OQXkAo17qRSEonWW4HtLbtmS8He1JNPc/n3dVUm+fM6NoDXPoLP7j55G
++9zKyqGtGAWXAj1MTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACtGNdj5TEtnJBYp
++M+LhBeU3oNteldfycEm993gJp6ghWZFg23oX8fVmyEeJr/3Ca9bAgDqg0t9a0npN
++oWKEY6wVKqcHgu3gSvThF5c9KhGbeDDmlTSVVNQmXWX0K2d4lS2cwZHH8mCm2mrY
++PDqlEkSc7k4qSiqigdS8i80Yk+lDXWsm8CjsiC93qaRM7DnS0WPQR0c16S95oM6G
++VklFKUSDAuFjw9aVWA/nahOucjn0w5fVW6lyIlkBslC1ChlaDgJmvhz+Ol3iMsE0
++kAmFNu2KKPVrpMWaBID49QwQTDyhetNLaVVFM88iUdA9JDoVMEuP1mm39JqyzHTu
++uBrdP4Q=
+ -----END CERTIFICATE-----
+diff --git a/test/net/fixtures/server.key b/test/net/fixtures/server.key
+index 7f2380e71e..6a83d5bcf4 100644
+--- a/test/net/fixtures/server.key
++++ b/test/net/fixtures/server.key
+@@ -1,28 +1,27 @@
+------BEGIN PRIVATE KEY-----
+-MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDo2pwBLisQ7EnN
+-XgcTB5xwnsZ0vBPC4W/Ggv3jSOAspWjHnkLeYFRl5moUV3ow0My1ttnD0t/JJZdU
+-Z8/2vl7Li+4DxeHi+ef30QxH8LjaM1qtQa3ntaJ7t78w2mD441SivDr9G3TZ3HRC
+-6Sm+36y0T+sy9Abx4YxLqIv7Keexvx0B7nMP+UDc1RV52cZz0MDdy+TaGUeAxhQE
+-cv2afI8RgnZJBHnM8lwxIpUTPl1Apk3gowImfVI7u+1loQ/ta7A81N5hFV7T3WgJ
+-n0pXpcKpbYaSxfSk1LcTO1JjJAXizOOKPNQ1NCsQu1hy5+GNHXSMYRYgPdAcTo9u
+-/f5kEE9BAgMBAAECggEBAOHkwhc7DLh8IhTDNSW26oMu5OP2WU1jmiYAigDmf+OQ
+-DBgrZj+JQBci8qINQxL8XLukSZn5hvQCLc7Kbyu1/wyEEUFDxSGGwwzclodr9kho
+-LX2LDASPZrOSzD2+fPi2wTKmXKuS6Uc44OjQfZkYMNkz9r4Vkm8xGgOD3VipjIYX
+-QXlhhdqkXZcNABsihCV52GKkDFSVm8jv95YJc5xhoYCy/3a4/qPdF0aT2R7oYUej
+-hKrxVDskyooe8Zg/JTydZNV5GQEDmW01/K3r6XGT26oPi1AqMU1gtv/jkW56CRQQ
+-1got8smnqM+AV7Slf9R6DauIPdQJ2S8wsr/o8ISBsOECgYEA9YrqEP2gAYSGFXRt
+-liw0WI2Ant8BqXS6yvq1jLo/qWhLw/ph4Di73OQ2mpycVTpgfGr2wFPQR1XJ+0Fd
+-U+Ir/C3Q7FK4VIGHK7B0zNvZr5tEjlFfeRezo2JMVw5YWeSagIFcSwK+KqCTH9qc
+-pw/Eb8nB/4XNcpTZu7Fg0Wc+ooUCgYEA8sVaicn1Wxkpb45a4qfrA6wOr5xdJ4cC
+-A5qs7vjX2OdPIQOmoQhdI7bCWFXZzF33wA4YCws6j5wRaySLIJqdms8Gl9QnODy1
+-ZlA5gwKToBC/jqPmWAXSKb8EH7cHilaxU9OKnQ7CfwlGLHqjMtjrhR7KHlt3CVRs
+-oRmvsjZVXI0CgYAmPedslAO6mMhFSSfULrhMXmV82OCqYrrA6EEkVNGbcdnzAOkD
+-gfKIWabDd8bFY10po4Mguy0CHzNhBXIioWQWV5BlbhC1YKMLw+S9DzSdLAKGY9gJ
+-xQ4+UQ3wtRQ/k+IYR413RUsW2oFvgZ3KSyNeAb9MK6uuv84VdG/OzVSs/QKBgQDn
+-kap//l2EbObiWyaERunckdVcW0lcN+KK75J/TGwPoOwQsLvTpPe65kxRGGrtDsEQ
+-uCDk/+v3KkZPLgdrrTAih9FhJ+PVN8tMcb+6IM4SA4fFFr/UPJEwct0LJ3oQ0grJ
+-y+HPWFHb/Uurh7t99/4H98uR02sjQh1wOeEmm78mzQKBgQDm+LzGH0se6CXQ6cdZ
+-g1JRZeXkDEsrW3hfAsW62xJQmXcWxBoblP9OamMY+A06rM5og3JbDk5Zm6JsOaA8
+-wS2gw4ilp46jors4eQey8ux7kB9LzdBoDBBElnsbjLO8oBNZlVcYXg+6BOl/CUi7
+-2whRF0FEjKA8ehrNhAq+VFfFNw==
+------END PRIVATE KEY-----
++-----BEGIN RSA PRIVATE KEY-----
++MIIEowIBAAKCAQEAsPnoGUOnrpiSqt4XynxA+HRP7S+BSObI6qJ7fQAVSPtRkqso
++tWxQYLEYzNEx5ZSHTGypibVsJylvCfuToDTfMul8b/CZjP2Ob0LdpYrNH6l5hvFE
++89FU1nZQF15oVLOpUgA7wGiHuEVawrGfey92UE68mOyUVXGweJIVDdxqdMoPvNNU
++l86BU02vlBiESxOuox+dWmuVV7vfYZ79Toh/LUK43YvJh+rhv4nKuF7iHjVjBd9s
++B6iDjj70HFldzOQ9r8SRI+9NirupPTkF5AKNe6kUhKJ1luB7S27ZkvB3tSTT3P59
++3VVJvnzOjaA1z6Cz+4+eRvcysqhrRgFlwI9TEwIDAQABAoIBAEEYiyDP29vCzx/+
++dS3LqnI5BjUuJhXUnc6AWX/PCgVAO+8A+gZRgvct7PtZb0sM6P9ZcLrweomlGezI
++FrL0/6xQaa8bBr/ve/a8155OgcjFo6fZEw3Dz7ra5fbSiPmu4/b/kvrg+Br1l77J
++aun6uUAs1f5B9wW+vbR7tzbT/mxaUeDiBzKpe15GwcvbJtdIVMa2YErtRjc1/5B2
++BGVXyvlJv0SIlcIEMsHgnAFOp1ZgQ08aDzvilLq8XVMOahAhP1O2A3X8hKdXPyrx
++IVWE9bS9ptTo+eF6eNl+d7htpKGEZHUxinoQpWEBTv+iOoHsVunkEJ3vjLP3lyI/
++fY0NQ1ECgYEA3RBXAjgvIys2gfU3keImF8e/TprLge1I2vbWmV2j6rZCg5r/AS0u
++pii5CvJ5/T5vfJPNgPBy8B/yRDs+6PJO1GmnlhOkG9JAIPkv0RBZvR0PMBtbp6nT
++Y3yo1lwamBVBfY6rc0sLTzosZh2aGoLzrHNMQFMGaauORzBFpY5lU50CgYEAzPHl
++u5DI6Xgep1vr8QvCUuEesCOgJg8Yh1UqVoY/SmQh6MYAv1I9bLGwrb3WW/7kqIoD
++fj0aQV5buVZI2loMomtU9KY5SFIsPV+JuUpy7/+VE01ZQM5FdY8wiYCQiVZYju9X
++Wz5LxMNoz+gT7pwlLCsC4N+R8aoBk404aF1gum8CgYAJ7VTq7Zj4TFV7Soa/T1eE
++k9y8a+kdoYk3BASpCHJ29M5R2KEA7YV9wrBklHTz8VzSTFTbKHEQ5W5csAhoL5Fo
++qoHzFFi3Qx7MHESQb9qHyolHEMNx6QdsHUn7rlEnaTTyrXh3ifQtD6C0yTmFXUIS
++CW9wKApOrnyKJ9nI0HcuZQKBgQCMtoV6e9VGX4AEfpuHvAAnMYQFgeBiYTkBKltQ
++XwozhH63uMMomUmtSG87Sz1TmrXadjAhy8gsG6I0pWaN7QgBuFnzQ/HOkwTm+qKw
++AsrZt4zeXNwsH7QXHEJCFnCmqw9QzEoZTrNtHJHpNboBuVnYcoueZEJrP8OnUG3r
++UjmopwKBgAqB2KYYMUqAOvYcBnEfLDmyZv9BTVNHbR2lKkMYqv5LlvDaBxVfilE0
++2riO4p6BaAdvzXjKeRrGNEKoHNBpOSfYCOM16NjL8hIZB1CaV3WbT5oY+jp7Mzd5
++7d56RZOE+ERK2uz/7JX9VSsM/LbH9pJibd4e8mikDS9ntciqOH/3
++-----END RSA PRIVATE KEY-----
+-- 
+cgit v1.2.3
+

--- a/recipes-debian/ruby/ruby/run-ptest
+++ b/recipes-debian/ruby/ruby/run-ptest
@@ -1,13 +1,11 @@
 #!/bin/sh
 
-test_fullname=`find test -name test_*.rb` 
- 
-for i in ${test_fullname}; do 
-	ruby ./test/runner.rb ${i}  2>&1 > /dev/null
-	ret=$? 
-	if [ $ret != 0 ]; then
-		echo "FAIL: ${i}" 
-	else
-		echo "PASS: ${i}"         
-	fi 
-done 
+if ! [ -L /usr/bin/ruby2.5 ]; then
+  $(cd /usr/bin/; ln -s ruby ruby2.5)
+fi
+if id -u ruby-test > /dev/null; then
+   userdel ruby-test
+fi
+useradd ruby-test > /dev/null
+PERL5LIB=/usr/lib/perl/5.28.1 su ruby-test -c "tests/run-all $@"
+userdel ruby-test > /dev/null

--- a/recipes-debian/ruby/ruby_debian.bb
+++ b/recipes-debian/ruby/ruby_debian.bb
@@ -10,6 +10,9 @@ require ruby.inc
 SRC_URI += " \
            file://0001-configure.ac-check-finite-isinf-isnan-as-macros-firs.patch \
            file://run-ptest \
+           file://add-test-preparation-and-fix-result-output.patch \
+           file://renew-test-certificates.patch \
+           file://fix-for-tzdata-2022g.patch \
            "
 
 PACKAGECONFIG ??= ""
@@ -56,6 +59,9 @@ do_install_append_class-target () {
 
 do_install_ptest () {
     cp -rf ${S}/test ${D}${PTEST_PATH}/
+    cp -rf ${S}/debian/tests ${D}${PTEST_PATH}/
+    mkdir -p ${D}${PTEST_PATH}/bin/
+    ln -s ${bindir}/erb ${D}${PTEST_PATH}/bin/erb
     cp -r ${S}/include ${D}/${libdir}/ruby/
     test_case_rb=`grep rubygems/test_case.rb ${B}/.installed.list`
     sed -i -e 's:../../../test/:../../../ptest/test/:g' ${D}/$test_case_rb
@@ -76,6 +82,10 @@ FILES_${PN} += "${libdir}/ruby/2.5.0/"
 FILES_${PN} += "${libdir}/ruby/gems"
 FILES_${PN} += "${libdir}/ruby/site_ruby"
 FILES_${PN} += "${libdir}/ruby/vendor_ruby"
+
+RDEPENDS_${PN}-ptest += " dpkg dpkg-perl findutils make coreutils"
+RDEPENDS_${PN}-ptest += " ${PN}-rdoc ${PN}-ri-docs "
+RDEPENDS_${PN}-ptest += " openssl readline libyaml zlib libffi gmp gperf tzdata openssh"
 
 FILES_${PN}-ptest_append_class-target += "${libdir}/ruby/include"
 


### PR DESCRIPTION
# Purpose of pull request
Modify ruby's ptest run-ptest from Poky-based to use Debian-based debian/tests/run-all.

- Modified run-ptest to call debian's tests/run-all.
- Added packages required for testing to RDEPENDS.
- Modified for test targets as follows:
  - test/rubygems/test_gem_util.rb  
    Modified run-ptest that created "ruby-test" user and call run-all with that user.
  - test/rubygems/test_gem_ext_builder.rb  
    Add coreutils to RDEPENDS for use "install" command in test.
  - test/erb/test_erb_command.rb  
    In the recipe, installed symbolic link to /usr/bin/erb in ptest/bin/erb.  
    In the run-all fix in add-test-preparation-and-fix-result-output.patch, add a step to copy the bin directory to the test working directory. 
  - test/net/ftp/test_ftp.rb  
    Add renew-test-certificates.patch which fixes the certificate expiration date.
  - test/ruby/test_time_tz.rb  
     Add add-test-preparation-and-fix-result-output.patch to fix the test code with Singapore time changed by tzdata-2022g.

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment

## How to test the package
1. Build qemuarm64 image
2. Run qemu image
3. Run ruby ptest

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
Adding Kernel-module is for IPv6 testing.
```
IMAGE_INSTALL_append = " ruby-ptest"
CORE_IMAGE_EXTRA_INSTALL += " kernel-modules"
IMAGE_INSTALL_append = " kmod"
```
```
$ bitbake core-image-minimal
```

### Run qemu image
```
$ runqemu qemuarm64 nographic qemuparams="-smp 4 -m 4096"
```

### Run ruby ptest
```
# ptest-runner -t 7200 ruby | tee ruby.ptest.log
```

## Test result
This test was run on Ruby's debian package version “2.5.5-3+deb10u6”.
```
meta-debian-extended$ grep 'DPV =' ./recipes-debian/sources/ruby2.5.inc
DPV = "2.5.5-3+deb10u6"
```

### Build package
Build succeeded.
```
$ bitbake ruby
Parsing recipes: 100% |#################################################################################################| Time: 0:00:17
Parsing of 1360 .bb files complete (0 cached, 1360 parsed). 2382 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:ed4ace81663b05209a94a7f99815a0d600276588"
meta-debian-extended = "fix-ruby-ptest:3a8da7c438ae7d9212c5fd956f6849ce0b141c85"
meta-emlinux         = "HEAD:5944caff09396a9f1bd10897e86f4c839b740ac3"
meta-emlinux-private = "HEAD:3534c7782ba150055729db6720e5c10264c2d0e7"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 473 Found 0 Missed 473 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2178 tasks of which 0 didn't need to be rerun and all succeeded.
```

### Package test
All tests passed except for "FAIL: (EXPECTED)".  
These are listed in debian/tests/known-failures.txt file as test items that will fail in Debian.
```
Finished
--------
   Tests executed: 749
             PASS: 735
             FAIL: 0
EXPECTED FAILURES: 14

DURATION: 4200
END: /usr/lib/ruby/ptest
2024-12-18T12:51
STOP: ptest-runner
```
```
root@qemuarm64:~# grep -c '^PASS:' ruby.ptest.log
735
root@qemuarm64:~# grep -c '^SKIP:' ruby.ptest.log
0
root@qemuarm64:~# grep -c '^FAIL:' ruby.ptest.log
14
root@qemuarm64:~# grep '^FAIL:' ruby.ptest.log
FAIL: (EXPECTED) test/mkmf/test_constant.rb
FAIL: (EXPECTED) test/mkmf/test_convertible.rb
FAIL: (EXPECTED) test/mkmf/test_flags.rb
FAIL: (EXPECTED) test/mkmf/test_have_func.rb
FAIL: (EXPECTED) test/mkmf/test_have_library.rb
FAIL: (EXPECTED) test/mkmf/test_have_macro.rb
FAIL: (EXPECTED) test/mkmf/test_signedness.rb
FAIL: (EXPECTED) test/mkmf/test_sizeof.rb
FAIL: (EXPECTED) test/ripper/test_files.rb
FAIL: (EXPECTED) test/ruby/test_fiber.rb
FAIL: (EXPECTED) test/ruby/test_io.rb
FAIL: (EXPECTED) test/rubygems/test_gem.rb
FAIL: (EXPECTED) test/rubygems/test_gem_commands_environment_command.rb
FAIL: (EXPECTED) test/rubygems/test_gem_commands_update_command.rb
```