### PR TITLE
libevent: Backport from Poky-master for fix ptest 

### DIFF
--- a/recipes-debian/libevent/libevent/run-ptest
+++ b/recipes-debian/libevent/libevent/run-ptest
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+fail=0
+for test in ./test/*
+do
+	$test
+	if [ $? -ne 0 ]
+	then
+		fail=1
+	fi
+done
+
+if [ $fail -eq 0 ]
+then
+	echo "PASS: libevent"
+else
+	echo "FAIL: libevent"
+fi

--- a/recipes-debian/libevent/libevent/run-ptest
+++ b/recipes-debian/libevent/libevent/run-ptest
@@ -1,18 +1,29 @@
 #!/bin/sh
 
-fail=0
-for test in ./test/*
-do
-	$test
-	if [ $? -ne 0 ]
-	then
-		fail=1
-	fi
-done
+# run-ptest - 'ptest' test infrastructure shell script that
+#   wraps the libevent test scripts
+#
+# Trevor Gamblin <trevor.gamblin@windriver.com>
+###############################################################
+LIBEVENTLIB=@libdir@/libevent
+LOG="${LIBEVENTLIB}/ptest/libevent_ptest_$(date +%Y%m%d-%H%M%S).log"
 
-if [ $fail -eq 0 ]
-then
-	echo "PASS: libevent"
-else
-	echo "FAIL: libevent"
-fi
+cd ${LIBEVENTLIB}/ptest
+
+# Run only the libevent "regress" test. All other test scripts in the
+# libevent "test" folder are related to performance, e.g. read/write
+# rates, and/or do not provide a pass/fail output that can be recorded
+# in the ptest log.
+./test/regress 2>&1| sed -e '/TESTS/d' -e '/tests/d' -e '/OK/ s/^/PASS: / ; /FAILED/ s/^/FAIL: / ; /SKIPPED/ s/^/SKIP: / ; /DISABLED/ s/^/SKIP: /' | cut -f1,2 -d ':' | tee -a ${LOG}
+
+passed=`grep PASS: ${LOG}|wc -l`
+failed=`grep FAIL: ${LOG}|wc -l`
+skipped=`grep -E SKIP: ${LOG}|wc -l`
+all=$((passed + failed + skipped))
+
+(   echo "=== Test Summary ==="
+    echo "TOTAL: ${all}"
+    echo "PASSED: ${passed}"
+    echo "FAILED: ${failed}"
+    echo "SKIPPED: ${skipped}"
+) | tee -a ${LOG}

--- a/recipes-debian/libevent/libevent_debian.bb
+++ b/recipes-debian/libevent/libevent_debian.bb
@@ -48,4 +48,7 @@ do_install_ptest() {
 	do
 		install -m 0755 $file ${D}${PTEST_PATH}/test
 	done
+
+	# handle multilib
+	sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
 }


### PR DESCRIPTION
# Purpose of pull request
The libevent-ptest is implemented in poky, but aggregates all test results and displays only PASS or FAIL as a single result.
So, fix ptest by backporting from poky-master to display test results by test item.

# Test
## How to test the package
1. Build qemuarm64 image
2. Run qemu image
3. Run libevent ptest

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
MACHINE = "qemuarm64"
DISTRO = "emlinux"
IMAGE_INSTALL_append = " libevent libevent-ptest"
```
```
$ bitbake core-image-minimal
```

### Run qemu image
```
$ runqemu qemuarm64 nographic
```

### Run libevent ptest
```
# ptest-runner -t 7200 libevent | tee libevent.ptest.log
```

## Test result
### Build package
Build succeeded.
```
build$ bitbake libevent
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2382 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:af23a27ddaa025c5a3a2c4c2211fb644d24b80e0"
meta-debian-extended = "fix-libevent-ptest:2e01cbedade4f2bb116a6ebfcd382eef7ff9d602"
meta-emlinux         = "HEAD:ba97d46a9b0f38d3220e49db8c4bbde158544226"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 0 Found 0 Missed 0 Current 94 (0% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 660 tasks of which 660 didn't need to be rerun and all succeeded.
```

### Package test
As expected, all passed except for one FAIL.
```
=== Test Summary ===
TOTAL: 293
PASSED: 275
FAILED: 1
SKIPPED: 17
DURATION: 111
END: /usr/lib/libevent/ptest
2025-02-18T09:11
STOP: ptest-runner
```
```
root@qemuarm64:~# grep -c '^PASS:' libevent.ptest.log
275
root@qemuarm64:~# grep -c '^SKIP:' libevent.ptest.log
17
root@qemuarm64:~# grep -c '^FAIL:' libevent.ptest.log
1
root@qemuarm64:~# grep -C 3 '^FAIL:' libevent.ptest.log
PASS: util/monotonic_prc_precise
util/monotonic_prc_fallback: 
  FAIL ../libevent-2.1.8-stable/test/regress_util.c:1370
FAIL:   [monotonic_prc_fallback FAILED]
PASS: util/date_rfc1123
PASS: bufferevent/bufferevent
PASS: bufferevent/bufferevent_pair
```

For reference, here are the results before applying this PR:
```
FAIL: libevent
DURATION: 133
END: /usr/lib/libevent/ptest
2025-02-18T09:50
STOP: ptest-runner
```
```
root@qemuarm64:~# grep -n -C 5 'FAILED' libevent.ptest.log
148-util/monotonic_res_fallback: DISABLED
149-util/monotonic_prc: OK
150-util/monotonic_prc_precise: OK
151-util/monotonic_prc_fallback: 
152-  FAIL ../libevent-2.1.8-stable/test/regress_util.c:1370: assert(diff.tv_sec == 0): 1 vs 0
153:  [monotonic_prc_fallback FAILED]
154-util/date_rfc1123: OK
155-bufferevent/bufferevent: [forking] OK
156-bufferevent/bufferevent_pair: [forking] OK
157-bufferevent/bufferevent_flush_normal: [forking] OK
158-bufferevent/bufferevent_flush_flush: [forking] OK
--
311-listener/randport_ts: [forking] OK
312-listener/error_unlock: [forking] [warn] Error from accept() call: Too many open files
313-OK
314-listener/error: [forking] OK
315-listener/error_ts: [forking] OK
316:1/276 TESTS FAILED. (17 skipped)
317-write callback. should only see this once
318-timeout fired, time to end test
319-usec used=4024, usec passed=1499393, cpu usage=0.27%
320-closed_cb: detected socket close with success
321-=====expected
```
