### PR TITLE
clamav: workaround: Update version from 0.103.9+dfsg-0+deb10u1 to 0.103.12+dfsg-1+deb9u1

### DIFF
--- a/recipes-debian/clamav/clamav_debian.bb
+++ b/recipes-debian/clamav/clamav_debian.bb
@@ -21,8 +21,8 @@ BINCONFIG = "${bindir}/clamav-config"
 
 inherit cmake chrpath pkgconfig useradd systemd multilib_header multilib_script
 inherit debian-package
-require recipes-debian/sources/clamav.inc
-DEBIAN_UNPACK_DIR = "${WORKDIR}/${BPN}-${REPACK_PV}"
+require recipes-debian/clamav/clamav_stretch.inc
+DEBIAN_UNPACK_DIR = "${WORKDIR}/${BPN}-${PV}"
 
 SRC_URI += "file://clamd.conf \
            file://freshclam.conf \

--- a/recipes-debian/clamav/clamav_stretch.inc
+++ b/recipes-debian/clamav/clamav_stretch.inc
@@ -1,0 +1,29 @@
+#
+# Copyright Cybertrust Japan Co., Ltd. 2025
+#
+# The ClamAV package for Debian 10 has been upgraded and the major
+# version has changed. To build the new ClamAV package needs to prepare
+# rust-toolchains and a newer cmake.
+#
+# This file enables to install the ClamAV package for Debian 9 which
+# has been already fixed the some CVEs, as a workaround.
+#
+
+DPV = "0.103.12+dfsg-0+deb9u1"
+DPV_EPOCH = ""
+REPACK_PV = "0.103.12+dfsg"
+PV = "0.103.12"
+
+DEBIAN_SRC_URI = " \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/c/clamav/clamav_0.103.12+dfsg-0+deb9u1.dsc;name=clamav_0.103.12+dfsg-0+deb9u1.dsc \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/c/clamav/clamav_0.103.12+dfsg.orig.tar.xz;name=clamav_0.103.12+dfsg.orig.tar.xz \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/c/clamav/clamav_0.103.12+dfsg-0+deb9u1.debian.tar.xz;name=clamav_0.103.12+dfsg-0+deb9u1.debian.tar.xz \
+"
+
+SRC_URI[clamav_0.103.12+dfsg-0+deb9u1.dsc.md5sum] = "94b12140e9d25dc007ca90a988c4fea9"
+SRC_URI[clamav_0.103.12+dfsg.orig.tar.xz.md5sum] = "75461fd265ef1646c62341bca283b6ec"
+SRC_URI[clamav_0.103.12+dfsg-0+deb9u1.debian.tar.xz.md5sum] = "2b46a06c03b7f8bd12f2342e95c67eef"
+
+SRC_URI[clamav_0.103.12+dfsg-0+deb9u1.dsc.sha256sum] = "e84e540a4bee83467b6b37a1a57f21a2baf4fa0f9a77f20d8365d1c650de8976"
+SRC_URI[clamav_0.103.12+dfsg.orig.tar.xz.sha256sum] = "71635e5c908b621362f4b7520f4a44c58839d1e0eaa50d3a0bfb761b543b6e34"
+SRC_URI[clamav_0.103.12+dfsg-0+deb9u1.debian.tar.xz.sha256sum] = "177fbff28fb334772b34fc75df59d6aa4712b5607b07c06830eea83507c442c6"


### PR DESCRIPTION
# Purpose of pull request

This version fixes following CVEs.

- CVE-2024-20505
- CVE-2024-20506

ELA: ELA-1268-1

The ClamAV package for Debian 10 has been upgraded and the major version number has been changed. To build the new ClamAV package we need to prepare rust-toolchains and a newer cmake.

This commit enables to install the ClamAV package for Debian 9 which has been already fixed the above CVEs, as a workaround.

In this update, the package directory name in tarball has been changed to not include the repack string such as "+dfsg". Fixed DEBIAN_UNPACK_DIR to match this directory name change.

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment

## How to test the package
1. Build and run the qemuarm64 image
2. Run commands to check the freshclam and clamscan working

### Build and run the qemuarm64 image

Add the following to local.conf.
```shell
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " clamav"
IMAGE_INSTALL_append = " connman"
IMAGE_INSTALL_append = " wget"
DISTRO_FEATURES_append = " pam"
IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
```

Then build the image and run it on Qemu as follows.
```shell
$ bitbake core-image-minimal
$ runqemu nographic qemuarm64 slirp qemuparams="-smp 4 -m 2048"
```

### Run commands to check the freshclam and clamscan working
- (Optional) If necessary, set proxy server and private mirror server settings to /usr/etc/freshclam.conf.
  - The proxy server setting (10.2.200.16 is a proxy server as example):
    ```shell
    # echo 'HTTPProxyServer http://10.2.200.16:8080' >> /usr/etc/freshclam.conf
    ```

- Run the following commands to check freshclam works.
  ```shell
  # time freshclam
  # ls -la /var/lib/clamav/
  ```
- Run the following commands to check clamscan works.
  ```shell
  # wget -O eicar.com https://secure.eicar.org/eicar.com
  # clamscan ./eicar.com
  ```

## Test result
### Build package
Build succeeded.
```
$ bitbake clamav core-image-minimal
Loading cache: 100% |######################################################################| Time: 0:00:00
Loaded 2379 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:a891b7518f2fd5f07edbe4851e476e0bbdd0a965"
meta-debian-extended = "update-clamav_0.103.12-v2:5efefec89bb70ee3cc526509e234b615c94f80c0"
meta-emlinux         = "HEAD:c4eb164baa099b7096d9ea4365dd4b16f1db6f1e"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |#################################################################| Time: 0:00:01
Sstate summary: Wanted 1208 Found 0 Missed 1208 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 4056 tasks of which 288 didn't need to be rerun and all succeeded.
```

### Build package
Updated virus database by connecting the private mirror and checked to detect a sample virus successfully.

```shell
root@qemuarm64:~# time freshclam
Connecting via 10.2.200.16:8080
[   70.779272] random: crng init done
[   70.779921] random: 3 urandom warning(s) missed due to ratelimiting
Thu Jun 19 04:34:55 2025 -> ClamAV update process started at Thu Jun 19 04:34:55 2025
Thu Jun 19 04:34:55 2025 -> ^Your ClamAV installation is OUTDATED!
Thu Jun 19 04:34:55 2025 -> ^Local version: 0.103.12 Recommended version: 1.0.9
Thu Jun 19 04:34:55 2025 -> DON'T PANIC! Read https://docs.clamav.net/manual/Installing.html
Thu Jun 19 04:34:55 2025 -> daily database available for download (remote version: 27673)
Time:    6.0s, ETA:    0.0s [========================>]   61.68MiB/61.68MiB1.68MiB
Thu Jun 19 04:35:05 2025 -> Testing database: '/var/lib/clamav/tmp.179d4a1988/clamav-7aea0ac330aaeb9cd194c01bd0d932b5.tmp-daily.cvd' ...
Thu Jun 19 04:36:08 2025 -> Database test passed.
Thu Jun 19 04:36:08 2025 -> daily.cvd updated (version: 27673, sigs: 2075765, f-level: 90, builder: raynman)
Thu Jun 19 04:36:08 2025 -> main database available for download (remote version: 62)
Time:   20.8s, ETA:    0.0s [========================>]  162.58MiB/162.58MiB
Thu Jun 19 04:36:37 2025 -> Testing database: '/var/lib/clamav/tmp.179d4a1988/clamav-e1f22479dc0ad7d838f5927b2fad517c.tmp-main.cvd' ...
Thu Jun 19 04:42:43 2025 -> Database test passed.
Thu Jun 19 04:42:43 2025 -> main.cvd updated (version: 62, sigs: 6647427, f-level: 90, builder: sigmgr)
Thu Jun 19 04:42:43 2025 -> bytecode database available for download (remote version: 336)
Time:    0.6s, ETA:    0.0s [========================>]  277.52KiB/277.52KiB
Thu Jun 19 04:42:44 2025 -> Testing database: '/var/lib/clamav/tmp.179d4a1988/clamav-87e5cb4aba2a293dab0a16c7348953f7.tmp-bytecode.cvd' ...
Thu Jun 19 04:42:44 2025 -> Database test passed.
Thu Jun 19 04:42:44 2025 -> bytecode.cvd updated (version: 336, sigs: 83, f-level: 90, builder: nrandolp)
real    7m 51.16s
user    7m 10.58s
sys     0m 30.38s
root@qemuarm64:~
root@qemuarm64:~#
root@qemuarm64:~# ls -la /var/lib/clamav/
drwxr-xr-x    2 clamav   clamav        4096 Jun 19 04:42 .
drwxr-xr-x    7 root     root          4096 Jun 18 11:40 ..
-rw-r--r--    1 clamav   clamav      284179 Jun 19 04:42 bytecode.cvd
-rw-r--r--    1 clamav   clamav    64673875 Jun 19 04:35 daily.cvd
-rw-r--r--    1 clamav   clamav          69 Jun 19 04:34 freshclam.dat
-rw-r--r--    1 clamav   clamav   170479789 Jun 19 04:36 main.cvd
root@qemuarm64:~#
```

```shell
root@qemuarm64:~# clamscan --version
ClamAV 0.103.12
root@qemuarm64:~# clamscan ./eicar.com
/home/root/eicar.com: Win.Test.EICAR_HDB-1 FOUND

----------- SCAN SUMMARY -----------
Known viruses: 8707259
Engine version: 0.103.12
Scanned directories: 0
Scanned files: 1
Infected files: 1
Data scanned: 0.00 MB
Data read: 0.00 MB (ratio 0.00:1)
Time: 518.086 sec (8 m 38 s)
Start Date: 2025:06:19 04:52:40
End Date:   2025:06:19 05:01:19
root@qemuarm64:~#
```



