### PR TITLE
python3-certifi: Correct CVE_PRODUCT

### DIFF
--- a/recipes-debian/python/python-certifi.inc
+++ b/recipes-debian/python/python-certifi.inc
@@ -11,5 +11,6 @@ inherit debian-package
 require recipes-debian/sources/python-certifi.inc
 
 DEBIAN_UNPACK_DIR = "${WORKDIR}/python-certifi-${PV}"
+CVE_PRODUCT="certifi:certifi"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request

Correct CVE_PRODUCT for python3-certifi package.

# Test
## How to test
1. Add the following to local.conf
   ```
   MACHINE = "qemuarm64"
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   ```

2. Run cve_check for python3-certifi package 
   ```
   $ bitbake python3-certifi -c cve_check
   ```

## Test result

A CVE check was performed and the following three CVEs were reported:
- CVE-2022-23491: Unpatched
- CVE-2023-37920: Unpatched
- CVE-2024-39689: Patched

```
build$ bitbake python3-certifi -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:05
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "correct-python3-certifi-CVE-PRODUCT:330af1ae552308bb6558a3032095b7a781f357f2"
meta-emlinux         = "HEAD:010d4aab5b7696652b321a0501a4abc145c162bf"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: python3-certifi-2018.8.24-r0 do_cve_check: Found unpatched CVE (CVE-2022-23491 CVE-2023-37920), for more information check /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/python3-certifi/2018.8.24-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```
```
build@a6967bb97dc2:~/work/build$ cat tmp-glibc/work/aarch64-emlinux-linux/python3-certifi/2018.8.24-r0/temp/cve.log
PACKAGE NAME: python3-certifi
PACKAGE VERSION: 2018.8.24
CVE: CVE-2022-23491
CVE STATUS: Unpatched
CVE SUMMARY: Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi 2022.12.07 removes root certificates from "TrustCor" from the root store. These are in the process of being removed from Mozilla's trust store. TrustCor's root certificates are being removed pursuant to an investigation prompted by media reporting that TrustCor's ownership also operated a business that produced spyware. Conclusions of Mozilla's investigation can be found in the linked google group discussion.
CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 6.8
VECTOR: NETWORK
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2022-23491

PACKAGE NAME: python3-certifi
PACKAGE VERSION: 2018.8.24
CVE: CVE-2023-37920
CVE STATUS: Unpatched
CVE SUMMARY: Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi prior to version 2023.07.22 recognizes "e-Tugra" root certificates. e-Tugra's root certificates were subject to an investigation prompted by reporting of security issues in their systems. Certifi 2023.07.22 removes root certificates from "e-Tugra" from the root store.
CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 7.5
VECTOR: NETWORK
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2023-37920

PACKAGE NAME: python3-certifi
PACKAGE VERSION: 2018.8.24
CVE: CVE-2024-39689
CVE STATUS: Patched
CVE SUMMARY: Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi starting in 2021.5.30 and prior to 2024.7.4 recognized root certificates from `GLOBALTRUST`. Certifi 2024.7.04 removes root certificates from `GLOBALTRUST` from the root store. These are in the process of being removed from Mozilla's trust store. `GLOBALTRUST`'s root certificates are being removed pursuant to an investigation which identified "long-running and unresolved compliance issues."
CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 7.5
VECTOR: NETWORK
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-39689
```

### For information

Before this patch, CVE reports were not generated.
```
build@a6967bb97dc2:~/work/build$ bitbake python3-certifi -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:06
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "HEAD:010d4aab5b7696652b321a0501a4abc145c162bf"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```
```
build$ ls -la tmp-glibc/work/aarch64-emlinux-linux/python3-certifi/2018.8.24-r0/temp/
total 32
drwxr-xr-x 2 build build  4096 Aug 13 06:25 .
drwxr-xr-x 3 build build  4096 Aug 13 06:25 ..
lrwxrwxrwx 1 build build    20 Aug 13 06:25 log.do_cve_check -> log.do_cve_check.551
-rw-r--r-- 1 build build   286 Aug 13 06:25 log.do_cve_check.551
-rw-r--r-- 1 build build    41 Aug 13 06:25 log.task_order
-rw-r--r-- 1 build build  2430 Aug 13 06:25 run.debian_cve_check.551
lrwxrwxrwx 1 build build    20 Aug 13 06:25 run.do_cve_check -> run.do_cve_check.551
-rw-r--r-- 1 build build 10478 Aug 13 06:25 run.do_cve_check.551
```
