### PR TITLE
Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/glibc/cross-localedef-native_debian.bb
+++ b/recipes-debian/glibc/cross-localedef-native_debian.bb
@@ -54,3 +54,6 @@ do_install() {
 	install -d ${D}${bindir}
 	install -m 0755 ${B}/localedef ${D}${bindir}/cross-localedef
 }
+
+# CVE-2019-9192: There is no security impact.
+CVE_CHECK_WHITELIST = "CVE-2019-9192"

--- a/recipes-debian/jpeg/libjpeg-turbo_debian.bb
+++ b/recipes-debian/jpeg/libjpeg-turbo_debian.bb
@@ -65,3 +65,6 @@ DESCRIPTION_libturbojpeg = "A SIMD-accelerated JPEG codec which provides only Tu
 FILES_libturbojpeg = "${libdir}/libturbojpeg.so.*"
 
 BBCLASSEXTEND = "native"
+
+# CVE-2018-11813: This is not a security issue.
+CVE_CHECK_WHITELIST = "CVE-2018-11813"


### PR DESCRIPTION
# Purpose of pull request
Add CVEs to CVE_CHECK_WHITELIST.
* libjpeg-turbo / libjpeg-turbo-native: CVE-2018-11813
    * As upstream has determines, this is not a security issue.
* cross-localedef-native: CVE-2019-9192
    * This is glibc vulnerability. There is no security impact because cross-localedef-native does not use the vulnerable code in glibc.

# Test
## How to test
Add the following to local.conf.
```
MACHINE = "qemuarm64"
DISTRO = "emlinux-k510"
INHERIT += " cve-check debian-cve-check kernel-cve-check"
```

Run cve-check command.
```
bitbake libjpeg-turbo libjpeg-turbo-native cross-localedef-native -c cve_check
```
Then, compare the log (${WORKDIR}/temp/cve.log) between before and after this update.

## Test result

**Before this update:**
```
$ grep -A1 CVE-2018-11813 libjpeg-turbo.log 
CVE: CVE-2018-11813
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2018-11813

$ grep -A1 CVE-2018-11813 libjpeg-turbo-native.log 
CVE: CVE-2018-11813
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2018-11813

$ grep -A1 CVE-2019-9192 cross-localedef-native.log 
CVE: CVE-2019-9192
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2019-9192
```

**After this update:**
```
$ grep -A1 CVE-2018-11813 libjpeg-turbo.log 
CVE: CVE-2018-11813
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2018-11813

$ grep -A1 CVE-2018-11813 libjpeg-turbo-native.log 
CVE: CVE-2018-11813
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2018-11813

$ grep -A1 CVE-2019-9192 cross-localedef-native.log 
CVE: CVE-2019-9192
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2019-9192
```


