### PR TITLE
xserver-xorg: Add CVE-2024-31082 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/xorg-xserver/xserver-xorg_debian.bb
+++ b/recipes-debian/xorg-xserver/xserver-xorg_debian.bb
@@ -46,3 +46,7 @@ RCONFLICTS_${PN} = "${PN}-extension-dri \
                     ${PN}-extension-extmod \
                     ${PN}-extension-dbe \
                    "
+
+# CVE-2024-31082: This affects the XQuartz (libraries for macOS) ,
+#                 so this is false-positive for Linux.
+CVE_CHECK_WHITELIST = "CVE-2024-31082"


### PR DESCRIPTION
# Purpose of pull request
Add CVE-2024-31082 to CVE_CHECK_WHITELIST because this affects the XQuartz (libraries for macOS) , so this is false-positive for Linux.

# Test
## How to test
Add the following to local.conf.
```
MACHINE = "qemuarm64"
DISTRO = "emlinux"
INHERIT += " cve-check debian-cve-check"
```
Run cve-check command.
```
bitbake xserver-xorg -c cve_check
```

Then, compare the log (${WORKDIR}/temp/cve.log) between before and after this update.

## Test result
### Before this update:
```
$ grep -A1 CVE-2024-31082 /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/xserver-xorg/1.20.4-r0/temp/cve.log
CVE: CVE-2024-31082
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-31082
```

### After this update:
```
build@96b7b3392036:~/work/build$ grep -A1 CVE-2024-31082 /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/xserver-xorg/1.20.4-r0/temp/cve.log
CVE: CVE-2024-31082
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-31082
```